### PR TITLE
feat: domain verification failed notifications

### DIFF
--- a/backend/src/domains/services/domain-monitor.service.spec.ts
+++ b/backend/src/domains/services/domain-monitor.service.spec.ts
@@ -3,11 +3,13 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { DomainMonitorService } from './domain-monitor.service';
 import { DomainsService } from '../domains.service';
 import { Domain } from '../entities/domain.entity';
+import { EmailService } from '../../notifications/email.service';
 
 describe('DomainMonitorService', () => {
   let service: DomainMonitorService;
   let mockRepository: Record<string, jest.Mock>;
   let mockDomainsService: Record<string, jest.Mock>;
+  let mockEmailService: Record<string, jest.Mock>;
 
   const verifiedDomain: Domain = {
     id: 'd1',
@@ -15,7 +17,16 @@ describe('DomainMonitorService', () => {
     verificationCode: 'krakenkey-site-verification=abc',
     isVerified: true,
     userId: 'u1',
-    owner: {} as any,
+    owner: {
+      id: 'u1',
+      username: 'testuser',
+      email: 'test@example.com',
+      groups: [],
+      displayName: null,
+      createdAt: new Date(),
+      apiKeys: [],
+      tlsCrts: [],
+    },
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -30,6 +41,10 @@ describe('DomainMonitorService', () => {
       checkVerificationRecord: jest.fn(),
     };
 
+    mockEmailService = {
+      sendDomainVerificationFailed: jest.fn().mockResolvedValue(undefined),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         DomainMonitorService,
@@ -40,6 +55,10 @@ describe('DomainMonitorService', () => {
         {
           provide: DomainsService,
           useValue: mockDomainsService,
+        },
+        {
+          provide: EmailService,
+          useValue: mockEmailService,
         },
       ],
     }).compile();
@@ -59,9 +78,12 @@ describe('DomainMonitorService', () => {
       await service.checkVerifiedDomains();
 
       expect(mockRepository.update).not.toHaveBeenCalled();
+      expect(
+        mockEmailService.sendDomainVerificationFailed,
+      ).not.toHaveBeenCalled();
     });
 
-    it('marks domain as unverified when TXT record is missing', async () => {
+    it('marks domain as unverified and sends email when TXT record is missing', async () => {
       mockRepository.find.mockResolvedValue([verifiedDomain]);
       mockDomainsService.checkVerificationRecord.mockResolvedValue(false);
 
@@ -70,6 +92,32 @@ describe('DomainMonitorService', () => {
       expect(mockRepository.update).toHaveBeenCalledWith('d1', {
         isVerified: false,
       });
+      expect(
+        mockEmailService.sendDomainVerificationFailed,
+      ).toHaveBeenCalledWith({
+        username: 'testuser',
+        email: 'test@example.com',
+        hostname: 'example.com',
+        verificationCode: 'krakenkey-site-verification=abc',
+      });
+    });
+
+    it('skips email when domain has no owner', async () => {
+      const domainNoOwner = {
+        ...verifiedDomain,
+        owner: undefined as any,
+      };
+      mockRepository.find.mockResolvedValue([domainNoOwner]);
+      mockDomainsService.checkVerificationRecord.mockResolvedValue(false);
+
+      await service.checkVerifiedDomains();
+
+      expect(mockRepository.update).toHaveBeenCalledWith('d1', {
+        isVerified: false,
+      });
+      expect(
+        mockEmailService.sendDomainVerificationFailed,
+      ).not.toHaveBeenCalled();
     });
 
     it('continues processing other domains when one errors', async () => {

--- a/backend/src/domains/services/domain-monitor.service.ts
+++ b/backend/src/domains/services/domain-monitor.service.ts
@@ -4,6 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Domain } from '../entities/domain.entity';
 import { DomainsService } from '../domains.service';
+import { EmailService } from '../../notifications/email.service';
 
 @Injectable()
 export class DomainMonitorService {
@@ -13,6 +14,7 @@ export class DomainMonitorService {
     @InjectRepository(Domain)
     private readonly domainsRepository: Repository<Domain>,
     private readonly domainsService: DomainsService,
+    private readonly emailService: EmailService,
   ) {}
 
   /**
@@ -28,6 +30,7 @@ export class DomainMonitorService {
   async checkVerifiedDomains(): Promise<void> {
     const verifiedDomains = await this.domainsRepository.find({
       where: { isVerified: true },
+      relations: ['owner'],
     });
 
     this.logger.log(
@@ -46,6 +49,15 @@ export class DomainMonitorService {
           this.logger.warn(
             `Domain ${domain.hostname} (id: ${domain.id}) failed re-verification — TXT record not found, marked as unverified`,
           );
+
+          if (domain.owner?.email) {
+            await this.emailService.sendDomainVerificationFailed({
+              username: domain.owner.username,
+              email: domain.owner.email,
+              hostname: domain.hostname,
+              verificationCode: domain.verificationCode,
+            });
+          }
         }
       } catch (err) {
         this.logger.error(

--- a/backend/src/notifications/email.service.ts
+++ b/backend/src/notifications/email.service.ts
@@ -8,6 +8,7 @@ import {
   certExpiryWarningTemplate,
   certFailedTemplate,
   certRevokedTemplate,
+  domainVerificationFailedTemplate,
 } from './templates';
 
 export interface CertEmailContext {
@@ -18,6 +19,13 @@ export interface CertEmailContext {
   expiresAt?: Date;
   daysUntilExpiry?: number;
   errorMessage?: string;
+}
+
+export interface DomainVerificationFailedContext {
+  username: string;
+  email: string;
+  hostname: string;
+  verificationCode: string;
 }
 
 @Injectable()
@@ -106,6 +114,16 @@ export class EmailService {
       ctx.email,
       `Certificate revoked: ${ctx.commonName}`,
       certRevokedTemplate(ctx),
+    );
+  }
+
+  async sendDomainVerificationFailed(
+    ctx: DomainVerificationFailedContext,
+  ): Promise<void> {
+    await this.send(
+      ctx.email,
+      `Domain verification failed: ${ctx.hostname}`,
+      domainVerificationFailedTemplate(ctx),
     );
   }
 }

--- a/backend/src/notifications/templates/index.ts
+++ b/backend/src/notifications/templates/index.ts
@@ -1,4 +1,7 @@
-import type { CertEmailContext } from '../email.service';
+import type {
+  CertEmailContext,
+  DomainVerificationFailedContext,
+} from '../email.service';
 
 function escapeHtml(str: string): string {
   return str
@@ -106,6 +109,27 @@ export function certRevokedTemplate(ctx: CertEmailContext): string {
       detail('Certificate ID', String(ctx.certId)),
       detail('Common Name', ctx.commonName),
       p('If you did not request this, please contact support immediately.'),
+    ].join(''),
+  );
+}
+
+export function domainVerificationFailedTemplate(
+  ctx: DomainVerificationFailedContext,
+): string {
+  return layout(
+    'Domain Verification Failed',
+    [
+      p(
+        `Hi ${ctx.username}, the DNS verification record for your domain is no longer detected.`,
+      ),
+      detail('Domain', ctx.hostname),
+      p(
+        'The domain has been marked as unverified. New certificate requests for this domain will be blocked until the TXT record is restored and the domain is re-verified.',
+      ),
+      detail('Expected TXT Record', ctx.verificationCode),
+      p(
+        'Please add the TXT record back to your DNS configuration and re-verify the domain in KrakenKey.',
+      ),
     ].join(''),
   );
 }


### PR DESCRIPTION
This pull request adds email notifications to inform users when their domain fails DNS verification and is marked as unverified. The implementation includes updates to the domain monitoring logic, the email service, and the notification templates, as well as comprehensive tests to ensure correct behavior.

**Domain monitoring and notification enhancements:**

* The `DomainMonitorService` now injects the `EmailService` and, when a domain fails DNS verification, sends an email to the domain owner (if present) using a new `sendDomainVerificationFailed` method. The domain's owner is eagerly loaded to access email information. [[1]](diffhunk://#diff-65f2b2d7dc60c93355ec0ad731751ee3c7e77ee5d16ee7db18b57dbcb7f85e53R7) [[2]](diffhunk://#diff-65f2b2d7dc60c93355ec0ad731751ee3c7e77ee5d16ee7db18b57dbcb7f85e53R17) [[3]](diffhunk://#diff-65f2b2d7dc60c93355ec0ad731751ee3c7e77ee5d16ee7db18b57dbcb7f85e53R33) [[4]](diffhunk://#diff-65f2b2d7dc60c93355ec0ad731751ee3c7e77ee5d16ee7db18b57dbcb7f85e53R52-R60)

**Email service and template additions:**

* The `EmailService` adds a new `sendDomainVerificationFailed` method, which sends a notification using a newly defined `DomainVerificationFailedContext` and a new email template. [[1]](diffhunk://#diff-ac21ea7f4c64574b71282671d60855624d6225732eddeec45636a84edde4dc2eR11) [[2]](diffhunk://#diff-ac21ea7f4c64574b71282671d60855624d6225732eddeec45636a84edde4dc2eR24-R30) [[3]](diffhunk://#diff-ac21ea7f4c64574b71282671d60855624d6225732eddeec45636a84edde4dc2eR119-R128) [[4]](diffhunk://#diff-cd54b53b731c5fe6428e311f30a55af7ebb4547232cdef890c6a985d0cc42459L1-R4) [[5]](diffhunk://#diff-cd54b53b731c5fe6428e311f30a55af7ebb4547232cdef890c6a985d0cc42459R115-R135)

**Testing improvements:**

* The domain monitor service tests are updated to mock the `EmailService`, verify that emails are sent when appropriate, and ensure that emails are not sent when there is no owner. Additional test cases cover these scenarios. [[1]](diffhunk://#diff-6ffb80f8637a7f35166f806fea45b775e8f2021b7c83ac3a2dea20a90a97491eR6-R29) [[2]](diffhunk://#diff-6ffb80f8637a7f35166f806fea45b775e8f2021b7c83ac3a2dea20a90a97491eR44-R47) [[3]](diffhunk://#diff-6ffb80f8637a7f35166f806fea45b775e8f2021b7c83ac3a2dea20a90a97491eR59-R62) [[4]](diffhunk://#diff-6ffb80f8637a7f35166f806fea45b775e8f2021b7c83ac3a2dea20a90a97491eR81-R86) [[5]](diffhunk://#diff-6ffb80f8637a7f35166f806fea45b775e8f2021b7c83ac3a2dea20a90a97491eR95-R120)