### PR TITLE
Feature/hosted probe

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { BillingModule } from './billing/billing.module';
 import { OrganizationsModule } from './organizations/organizations.module';
 import { ProbesModule } from './probes/probes.module';
+import { EndpointsModule } from './endpoints/endpoints.module';
 import { RoleGuard } from './auth/guards/role.guard';
 
 @Module({
@@ -74,6 +75,7 @@ import { RoleGuard } from './auth/guards/role.guard';
     NotificationsModule,
     OrganizationsModule,
     ProbesModule,
+    EndpointsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { MetricsModule } from './metrics/metrics.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { BillingModule } from './billing/billing.module';
 import { OrganizationsModule } from './organizations/organizations.module';
+import { ProbesModule } from './probes/probes.module';
 import { RoleGuard } from './auth/guards/role.guard';
 
 @Module({
@@ -72,6 +73,7 @@ import { RoleGuard } from './auth/guards/role.guard';
     MetricsModule,
     NotificationsModule,
     OrganizationsModule,
+    ProbesModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -5,8 +5,10 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthentikProxyStrategy } from './strategies/authentik-proxy.strategy';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { ApiKeyStrategy } from './strategies/api-key.strategy';
+import { ServiceKeyStrategy } from './strategies/service-key.strategy';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserApiKey } from './entities/user-api-key.entity';
+import { ServiceApiKey } from './entities/service-api-key.entity';
 import { User } from '../users/entities/user.entity';
 import { Domain } from '../domains/entities/domain.entity';
 import { TlsCrt } from '../certs/tls/entities/tls-crt.entity';
@@ -15,10 +17,17 @@ import { BillingModule } from '../billing/billing.module';
 @Module({
   imports: [
     PassportModule.register({ defaultStrategy: 'jwt' }),
-    TypeOrmModule.forFeature([UserApiKey, User, Domain, TlsCrt]),
+    TypeOrmModule.forFeature([UserApiKey, ServiceApiKey, User, Domain, TlsCrt]),
     BillingModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, AuthentikProxyStrategy, JwtStrategy, ApiKeyStrategy],
+  providers: [
+    AuthService,
+    AuthentikProxyStrategy,
+    JwtStrategy,
+    ApiKeyStrategy,
+    ServiceKeyStrategy,
+  ],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { createHash } from 'crypto';
 import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UserApiKey } from './entities/user-api-key.entity';
+import { ServiceApiKey } from './entities/service-api-key.entity';
 import { User } from '../users/entities/user.entity';
 import { Domain } from '../domains/entities/domain.entity';
 import { TlsCrt } from '../certs/tls/entities/tls-crt.entity';
@@ -61,6 +62,10 @@ describe('AuthService', () => {
         {
           provide: getRepositoryToken(UserApiKey),
           useValue: mockUserApiKeyRepo,
+        },
+        {
+          provide: getRepositoryToken(ServiceApiKey),
+          useValue: { findOne: jest.fn(), create: jest.fn(), save: jest.fn() },
         },
         { provide: getRepositoryToken(User), useValue: mockUserRepo },
         { provide: getRepositoryToken(Domain), useValue: { count: jest.fn() } },

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -4,10 +4,12 @@ import {
   NotFoundException,
   HttpException,
   UnauthorizedException,
+  type OnModuleInit,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { In, Repository } from 'typeorm';
 import { UserApiKey } from './entities/user-api-key.entity';
+import { ServiceApiKey } from './entities/service-api-key.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { createHash, randomBytes } from 'crypto';
 import { User } from '../users/entities/user.entity';
@@ -25,11 +27,15 @@ import type {
 } from '@krakenkey/shared';
 
 @Injectable()
-export class AuthService {
+export class AuthService implements OnModuleInit {
+  private readonly logger = new Logger(AuthService.name);
+
   constructor(
     private readonly config: ConfigService,
     @InjectRepository(UserApiKey)
     private userApiKeyRepo: Repository<UserApiKey>,
+    @InjectRepository(ServiceApiKey)
+    private serviceApiKeyRepo: Repository<ServiceApiKey>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     @InjectRepository(Domain)
@@ -38,6 +44,30 @@ export class AuthService {
     private readonly tlsCrtRepo: Repository<TlsCrt>,
     private readonly billingService: BillingService,
   ) {}
+
+  async onModuleInit() {
+    await this.seedServiceKey();
+  }
+
+  /**
+   * Seeds a service key from KK_PROBE_API_KEY env var on startup.
+   * Idempotent: skips if the hash already exists.
+   */
+  private async seedServiceKey() {
+    const rawKey = this.config.get<string>('KK_PROBE_API_KEY');
+    if (!rawKey) return;
+
+    const hash = createHash('sha256').update(rawKey).digest('hex');
+    const existing = await this.serviceApiKeyRepo.findOne({ where: { hash } });
+    if (existing) return;
+
+    const key = this.serviceApiKeyRepo.create({
+      name: 'probe-service-key',
+      hash,
+    });
+    await this.serviceApiKeyRepo.save(key);
+    this.logger.log('Service key seeded from KK_PROBE_SERVICE_KEY');
+  }
 
   // --- Authentik OIDC Redirects ---
 
@@ -366,5 +396,42 @@ export class AuthService {
       await this.userRepo.save(user);
     }
     return user;
+  }
+
+  // --- Service API Key Management ---
+
+  async validateServiceKey(rawKey: string): Promise<ServiceApiKey | null> {
+    const hash = createHash('sha256').update(rawKey).digest('hex');
+    const record = await this.serviceApiKeyRepo.findOne({ where: { hash } });
+    if (!record) return null;
+    if (record.revokedAt) return null;
+    if (record.expiresAt && record.expiresAt < new Date()) return null;
+    return record;
+  }
+
+  async createServiceKey(
+    name: string,
+    expiresAt?: string,
+  ): Promise<{ apiKey: string; id: string; name: string }> {
+    const rawKey = `kk_svc_${randomBytes(24).toString('hex')}`;
+    const hash = createHash('sha256').update(rawKey).digest('hex');
+
+    const key = this.serviceApiKeyRepo.create({
+      name,
+      hash,
+      ...(expiresAt ? { expiresAt: new Date(expiresAt) } : {}),
+    });
+    await this.serviceApiKeyRepo.save(key);
+
+    return { apiKey: rawKey, id: key.id, name: key.name };
+  }
+
+  async revokeServiceKey(keyId: string): Promise<void> {
+    const result = await this.serviceApiKeyRepo.update(keyId, {
+      revokedAt: new Date(),
+    });
+    if (result.affected === 0) {
+      throw new NotFoundException(`Service key #${keyId} not found`);
+    }
   }
 }

--- a/backend/src/auth/entities/service-api-key.entity.ts
+++ b/backend/src/auth/entities/service-api-key.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+import { ApiHideProperty } from '@nestjs/swagger';
+
+@Entity()
+export class ServiceApiKey {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @ApiHideProperty()
+  @Column({ unique: true })
+  hash: string;
+
+  @Column({ nullable: true })
+  expiresAt?: Date;
+
+  @Column({ nullable: true })
+  revokedAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/auth/guards/service-key.guard.ts
+++ b/backend/src/auth/guards/service-key.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class ServiceKeyGuard extends AuthGuard('service-key') {}

--- a/backend/src/auth/guards/service-or-user-key.guard.ts
+++ b/backend/src/auth/guards/service-or-user-key.guard.ts
@@ -1,0 +1,36 @@
+import {
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+/**
+ * Dual-auth guard for probe endpoints.
+ *
+ * Tries all three strategies in order:
+ * 1. service-key  (hosted probes: kk_svc_ prefix)
+ * 2. api-key      (connected probes: kk_ prefix)
+ * 3. jwt          (connected probes: OIDC JWT)
+ *
+ * The first strategy that returns a non-null user wins.
+ */
+@Injectable()
+export class ServiceOrUserKeyGuard extends AuthGuard([
+  'service-key',
+  'api-key',
+  'jwt',
+]) {
+  handleRequest(
+    err: any,
+    user: any,
+    _info: any,
+    _context: ExecutionContext,
+    _status?: any,
+  ) {
+    if (err || !user) {
+      throw err || new UnauthorizedException();
+    }
+    return user;
+  }
+}

--- a/backend/src/auth/strategies/api-key.strategy.ts
+++ b/backend/src/auth/strategies/api-key.strategy.ts
@@ -12,7 +12,10 @@ export class ApiKeyStrategy extends PassportStrategy(Strategy, 'api-key') {
 
   async validate(req: Request) {
     const authHeader = req.headers['authorization'];
-    if (!authHeader?.startsWith('Bearer kk_')) {
+    if (
+      !authHeader?.startsWith('Bearer kk_') ||
+      authHeader.startsWith('Bearer kk_svc_')
+    ) {
       // Not an API key token — return null so Passport tries other strategies
       return null;
     }

--- a/backend/src/auth/strategies/service-key.strategy.ts
+++ b/backend/src/auth/strategies/service-key.strategy.ts
@@ -1,0 +1,31 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-custom';
+import type { Request } from 'express';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class ServiceKeyStrategy extends PassportStrategy(
+  Strategy,
+  'service-key',
+) {
+  constructor(private readonly authService: AuthService) {
+    super();
+  }
+
+  async validate(req: Request) {
+    const authHeader = req.headers['authorization'];
+    if (!authHeader?.startsWith('Bearer kk_svc_')) {
+      return null;
+    }
+
+    const rawKey = authHeader.split(' ')[1];
+    const record = await this.authService.validateServiceKey(rawKey);
+    if (!record) throw new UnauthorizedException('Invalid service key');
+
+    return {
+      serviceKeyId: record.id,
+      isServiceKey: true,
+    };
+  }
+}

--- a/backend/src/billing/constants/plan-limits.ts
+++ b/backend/src/billing/constants/plan-limits.ts
@@ -7,6 +7,12 @@ export interface PlanLimits {
   totalActiveCerts: number;
   concurrentPending: number;
   renewalWindowDays: number;
+  monitoredEndpoints: number;
+  minScanInterval: number; // minutes
+  hostedProbeRegions: number;
+  hostedMonitoredEndpoints: number;
+  hostedScanInterval: number; // minutes, 0 = unavailable
+  scanResultRetentionDays: number;
 }
 
 export const PLAN_LIMITS: Record<SubscriptionPlan, PlanLimits> = {
@@ -17,6 +23,12 @@ export const PLAN_LIMITS: Record<SubscriptionPlan, PlanLimits> = {
     totalActiveCerts: 10,
     concurrentPending: 2,
     renewalWindowDays: 5,
+    monitoredEndpoints: 3,
+    minScanInterval: 60,
+    hostedProbeRegions: 0,
+    hostedMonitoredEndpoints: 0,
+    hostedScanInterval: 0,
+    scanResultRetentionDays: 5,
   },
   starter: {
     domains: 10,
@@ -25,6 +37,12 @@ export const PLAN_LIMITS: Record<SubscriptionPlan, PlanLimits> = {
     totalActiveCerts: 75,
     concurrentPending: 5,
     renewalWindowDays: 30,
+    monitoredEndpoints: 10,
+    minScanInterval: 30,
+    hostedProbeRegions: 0,
+    hostedMonitoredEndpoints: 0,
+    hostedScanInterval: 0,
+    scanResultRetentionDays: 30,
   },
   team: {
     domains: 25,
@@ -33,6 +51,12 @@ export const PLAN_LIMITS: Record<SubscriptionPlan, PlanLimits> = {
     totalActiveCerts: 375,
     concurrentPending: 25,
     renewalWindowDays: 30,
+    monitoredEndpoints: 50,
+    minScanInterval: 5,
+    hostedProbeRegions: 5,
+    hostedMonitoredEndpoints: 25,
+    hostedScanInterval: 15,
+    scanResultRetentionDays: 90,
   },
   business: {
     domains: 75,
@@ -41,6 +65,12 @@ export const PLAN_LIMITS: Record<SubscriptionPlan, PlanLimits> = {
     totalActiveCerts: 1500,
     concurrentPending: 100,
     renewalWindowDays: 30,
+    monitoredEndpoints: 200,
+    minScanInterval: 1,
+    hostedProbeRegions: 15,
+    hostedMonitoredEndpoints: 100,
+    hostedScanInterval: 5,
+    scanResultRetentionDays: 90,
   },
   enterprise: {
     domains: Infinity,
@@ -49,5 +79,11 @@ export const PLAN_LIMITS: Record<SubscriptionPlan, PlanLimits> = {
     totalActiveCerts: Infinity,
     concurrentPending: Infinity,
     renewalWindowDays: 30,
+    monitoredEndpoints: Infinity,
+    minScanInterval: 1,
+    hostedProbeRegions: Infinity,
+    hostedMonitoredEndpoints: Infinity,
+    hostedScanInterval: 1,
+    scanResultRetentionDays: 90,
   },
 } as const;

--- a/backend/src/endpoints/dto/add-hosted-region.dto.ts
+++ b/backend/src/endpoints/dto/add-hosted-region.dto.ts
@@ -1,0 +1,13 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AddHostedRegionDto {
+  @ApiProperty({
+    description: 'Hosted probe region identifier',
+    example: 'us-east-1',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(50)
+  region: string;
+}

--- a/backend/src/endpoints/dto/assign-probes.dto.ts
+++ b/backend/src/endpoints/dto/assign-probes.dto.ts
@@ -1,0 +1,13 @@
+import { IsArray, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AssignProbesDto {
+  @ApiProperty({
+    description: 'IDs of connected probes to assign',
+    example: ['probe-uuid-1'],
+  })
+  @IsArray()
+  @IsNotEmpty()
+  @IsString({ each: true })
+  probeIds: string[];
+}

--- a/backend/src/endpoints/dto/create-endpoint.dto.ts
+++ b/backend/src/endpoints/dto/create-endpoint.dto.ts
@@ -1,0 +1,50 @@
+import {
+  IsNotEmpty,
+  IsString,
+  IsInt,
+  IsOptional,
+  Min,
+  Max,
+  MaxLength,
+  IsFQDN,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateEndpointDto {
+  @ApiProperty({
+    description: 'Hostname to monitor',
+    example: 'example.com',
+  })
+  @IsNotEmpty()
+  @IsFQDN()
+  @MaxLength(253)
+  host: string;
+
+  @ApiPropertyOptional({
+    description: 'Port to connect to (default: 443)',
+    example: 443,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(65535)
+  port?: number;
+
+  @ApiPropertyOptional({
+    description: 'SNI override (defaults to host)',
+    example: 'example.com',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(253)
+  sni?: string;
+
+  @ApiPropertyOptional({
+    description: 'User-friendly label',
+    example: 'Production API',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  label?: string;
+}

--- a/backend/src/endpoints/dto/create-endpoint.dto.ts
+++ b/backend/src/endpoints/dto/create-endpoint.dto.ts
@@ -3,6 +3,7 @@ import {
   IsString,
   IsInt,
   IsOptional,
+  IsArray,
   Min,
   Max,
   MaxLength,
@@ -47,4 +48,22 @@ export class CreateEndpointDto {
   @IsString()
   @MaxLength(100)
   label?: string;
+
+  @ApiPropertyOptional({
+    description: 'IDs of connected probes to assign for scanning',
+    example: ['probe-uuid-1'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  probeIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Hosted probe regions to enable for scanning (Team tier+)',
+    example: ['us-east-1'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  hostedRegions?: string[];
 }

--- a/backend/src/endpoints/dto/update-endpoint.dto.ts
+++ b/backend/src/endpoints/dto/update-endpoint.dto.ts
@@ -1,4 +1,10 @@
-import { IsString, IsOptional, IsBoolean, MaxLength } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsArray,
+  MaxLength,
+} from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class UpdateEndpointDto {
@@ -27,4 +33,23 @@ export class UpdateEndpointDto {
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Connected probe IDs to assign (replaces existing assignments)',
+    example: ['probe-uuid-1'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  probeIds?: string[];
+
+  @ApiPropertyOptional({
+    description: 'Hosted probe regions to enable (replaces existing regions)',
+    example: ['us-east-1'],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  hostedRegions?: string[];
 }

--- a/backend/src/endpoints/dto/update-endpoint.dto.ts
+++ b/backend/src/endpoints/dto/update-endpoint.dto.ts
@@ -1,0 +1,30 @@
+import { IsString, IsOptional, IsBoolean, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateEndpointDto {
+  @ApiPropertyOptional({
+    description: 'SNI override',
+    example: 'example.com',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(253)
+  sni?: string;
+
+  @ApiPropertyOptional({
+    description: 'User-friendly label',
+    example: 'Production API',
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  label?: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether endpoint monitoring is active',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/backend/src/endpoints/endpoints.controller.spec.ts
+++ b/backend/src/endpoints/endpoints.controller.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EndpointsController } from './endpoints.controller';
+import { EndpointsService } from './endpoints.service';
+import { MetricsService } from '../metrics/metrics.service';
+import type { RequestWithUser } from '../auth/interfaces/request-with-user.interface';
+
+describe('EndpointsController', () => {
+  let controller: EndpointsController;
+  let service: Record<string, jest.Mock>;
+
+  const mockReq = {
+    user: { userId: 'user-123' },
+  } as unknown as RequestWithUser;
+
+  beforeEach(async () => {
+    service = {
+      create: jest.fn().mockResolvedValue({ id: 'ep-1', host: 'example.com' }),
+      findAll: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue({ id: 'ep-1' }),
+      update: jest.fn().mockResolvedValue({ id: 'ep-1' }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      addHostedRegion: jest
+        .fn()
+        .mockResolvedValue({ id: 'ehr-1', region: 'us-east-1' }),
+      removeHostedRegion: jest.fn().mockResolvedValue(undefined),
+      getResults: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+      getLatestResults: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EndpointsController],
+      providers: [
+        { provide: EndpointsService, useValue: service },
+        {
+          provide: MetricsService,
+          useValue: { authTotal: { inc: jest.fn() } },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<EndpointsController>(EndpointsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('create should call service.create with userId and dto', async () => {
+    const dto = { host: 'example.com' };
+    await controller.create(mockReq, dto);
+    expect(service.create).toHaveBeenCalledWith('user-123', dto);
+  });
+
+  it('findAll should call service.findAll with userId', async () => {
+    await controller.findAll(mockReq);
+    expect(service.findAll).toHaveBeenCalledWith('user-123');
+  });
+
+  it('findOne should call service.findOne', async () => {
+    await controller.findOne(mockReq, 'ep-1');
+    expect(service.findOne).toHaveBeenCalledWith('ep-1', 'user-123');
+  });
+
+  it('update should call service.update', async () => {
+    const dto = { label: 'Test' };
+    await controller.update(mockReq, 'ep-1', dto);
+    expect(service.update).toHaveBeenCalledWith('ep-1', 'user-123', dto);
+  });
+
+  it('remove should call service.delete', async () => {
+    await controller.remove(mockReq, 'ep-1');
+    expect(service.delete).toHaveBeenCalledWith('ep-1', 'user-123');
+  });
+
+  it('addRegion should call service.addHostedRegion', async () => {
+    await controller.addRegion(mockReq, 'ep-1', { region: 'us-east-1' });
+    expect(service.addHostedRegion).toHaveBeenCalledWith(
+      'ep-1',
+      'user-123',
+      'us-east-1',
+    );
+  });
+
+  it('removeRegion should call service.removeHostedRegion', async () => {
+    await controller.removeRegion(mockReq, 'ep-1', 'us-east-1');
+    expect(service.removeHostedRegion).toHaveBeenCalledWith(
+      'ep-1',
+      'user-123',
+      'us-east-1',
+    );
+  });
+
+  it('getResults should parse page and limit', async () => {
+    await controller.getResults(mockReq, 'ep-1', '2', '50');
+    expect(service.getResults).toHaveBeenCalledWith('ep-1', 'user-123', 2, 50);
+  });
+
+  it('getResults should cap limit at 100', async () => {
+    await controller.getResults(mockReq, 'ep-1', '1', '200');
+    expect(service.getResults).toHaveBeenCalledWith('ep-1', 'user-123', 1, 100);
+  });
+
+  it('getLatestResults should call service', async () => {
+    await controller.getLatestResults(mockReq, 'ep-1');
+    expect(service.getLatestResults).toHaveBeenCalledWith('ep-1', 'user-123');
+  });
+});

--- a/backend/src/endpoints/endpoints.controller.ts
+++ b/backend/src/endpoints/endpoints.controller.ts
@@ -9,7 +9,9 @@ import {
   Query,
   UseGuards,
   Request,
+  Res,
 } from '@nestjs/common';
+import type { Response } from 'express';
 import {
   ApiTags,
   ApiBearerAuth,
@@ -149,6 +151,38 @@ export class EndpointsController {
       page ? parseInt(page, 10) : 1,
       limit ? Math.min(parseInt(limit, 10), 100) : 20,
     );
+  }
+
+  @Get(':id/results/export')
+  @ApiOperation({ summary: 'Export raw scan results as CSV or JSON' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiQuery({
+    name: 'format',
+    required: false,
+    enum: ['json', 'csv'],
+    description: 'Export format (default: json)',
+  })
+  @ApiResponse({ status: 200, description: 'Exported scan results' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  async exportResults(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string,
+    @Query('format') format: string | undefined,
+    @Res() res: Response,
+  ) {
+    const fmt = format === 'csv' ? 'csv' : 'json';
+    const result = await this.endpointsService.exportResults(
+      id,
+      req.user.userId,
+      fmt,
+    );
+    res.setHeader('Content-Type', result.contentType);
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${result.filename}"`,
+    );
+    res.send(result.data);
   }
 
   @Get(':id/results/latest')

--- a/backend/src/endpoints/endpoints.controller.ts
+++ b/backend/src/endpoints/endpoints.controller.ts
@@ -24,6 +24,7 @@ import { EndpointsService } from './endpoints.service';
 import { CreateEndpointDto } from './dto/create-endpoint.dto';
 import { UpdateEndpointDto } from './dto/update-endpoint.dto';
 import { AddHostedRegionDto } from './dto/add-hosted-region.dto';
+import { AssignProbesDto } from './dto/assign-probes.dto';
 import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import type { RequestWithUser } from '../auth/interfaces/request-with-user.interface';
@@ -91,6 +92,51 @@ export class EndpointsController {
     return this.endpointsService.delete(id, req.user.userId);
   }
 
+  @Get('probes/mine')
+  @ApiOperation({
+    summary: "List the user's connected probes available for assignment",
+  })
+  @ApiResponse({ status: 200, description: 'List of connected probes' })
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  listUserProbes(@Request() req: RequestWithUser) {
+    return this.endpointsService.listUserProbes(req.user.userId);
+  }
+
+  @Post(':id/probes')
+  @ApiOperation({ summary: 'Assign connected probes to an endpoint' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiResponse({ status: 201, description: 'Probes assigned' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  assignProbes(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string,
+    @Body() dto: AssignProbesDto,
+  ) {
+    return this.endpointsService.assignProbes(
+      id,
+      req.user.userId,
+      dto.probeIds,
+    );
+  }
+
+  @Delete(':id/probes/:probeId')
+  @ApiOperation({ summary: 'Unassign a connected probe from an endpoint' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiParam({ name: 'probeId', description: 'Probe ID' })
+  @ApiResponse({ status: 200, description: 'Probe unassigned' })
+  @ApiResponse({ status: 404, description: 'Assignment not found' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  unassignProbe(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string,
+    @Param('probeId') probeId: string,
+  ) {
+    return this.endpointsService.unassignProbe(id, req.user.userId, probeId);
+  }
+
   @Post(':id/regions')
   @ApiOperation({ summary: 'Add a hosted probe region to an endpoint' })
   @ApiParam({ name: 'id', description: 'Endpoint UUID' })
@@ -129,6 +175,19 @@ export class EndpointsController {
       req.user.userId,
       region,
     );
+  }
+
+  @Post(':id/scan')
+  @ApiOperation({
+    summary: 'Request an on-demand scan of this endpoint',
+  })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiResponse({ status: 200, description: 'Scan requested' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  requestScan(@Request() req: RequestWithUser, @Param('id') id: string) {
+    return this.endpointsService.requestScan(id, req.user.userId);
   }
 
   @Get(':id/results')

--- a/backend/src/endpoints/endpoints.controller.ts
+++ b/backend/src/endpoints/endpoints.controller.ts
@@ -1,0 +1,165 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { EndpointsService } from './endpoints.service';
+import { CreateEndpointDto } from './dto/create-endpoint.dto';
+import { UpdateEndpointDto } from './dto/update-endpoint.dto';
+import { AddHostedRegionDto } from './dto/add-hosted-region.dto';
+import { JwtOrApiKeyGuard } from '../auth/guards/jwt-or-api-key.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import type { RequestWithUser } from '../auth/interfaces/request-with-user.interface';
+import { RateLimitCategoryDecorator } from '../throttler/decorators/rate-limit-category.decorator';
+import { RateLimitCategory } from '../throttler/interfaces/rate-limit-category.enum';
+
+@Controller('endpoints')
+@ApiTags('Endpoints')
+@ApiBearerAuth()
+@UseGuards(JwtOrApiKeyGuard)
+export class EndpointsController {
+  constructor(private readonly endpointsService: EndpointsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Register a new monitored endpoint' })
+  @ApiResponse({ status: 201, description: 'Endpoint created' })
+  @ApiResponse({ status: 403, description: 'Plan limit exceeded' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  create(@Request() req: RequestWithUser, @Body() dto: CreateEndpointDto) {
+    return this.endpointsService.create(req.user.userId, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List all monitored endpoints' })
+  @ApiResponse({ status: 200, description: 'List of endpoints' })
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  findAll(@Request() req: RequestWithUser) {
+    return this.endpointsService.findAll(req.user.userId);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get endpoint details' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiResponse({ status: 200, description: 'Endpoint details' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  findOne(@Request() req: RequestWithUser, @Param('id') id: string) {
+    return this.endpointsService.findOne(id, req.user.userId);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update endpoint' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiResponse({ status: 200, description: 'Endpoint updated' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  update(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateEndpointDto,
+  ) {
+    return this.endpointsService.update(id, req.user.userId, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete an endpoint' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiResponse({ status: 200, description: 'Endpoint deleted' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  remove(@Request() req: RequestWithUser, @Param('id') id: string) {
+    return this.endpointsService.delete(id, req.user.userId);
+  }
+
+  @Post(':id/regions')
+  @ApiOperation({ summary: 'Add a hosted probe region to an endpoint' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiResponse({ status: 201, description: 'Region added' })
+  @ApiResponse({ status: 403, description: 'Plan limit exceeded' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  addRegion(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string,
+    @Body() dto: AddHostedRegionDto,
+  ) {
+    return this.endpointsService.addHostedRegion(
+      id,
+      req.user.userId,
+      dto.region,
+    );
+  }
+
+  @Delete(':id/regions/:region')
+  @ApiOperation({ summary: 'Remove a hosted probe region from an endpoint' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiParam({ name: 'region', description: 'Region identifier' })
+  @ApiResponse({ status: 200, description: 'Region removed' })
+  @ApiResponse({ status: 404, description: 'Region not found' })
+  @Roles('owner', 'admin', 'member')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  removeRegion(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string,
+    @Param('region') region: string,
+  ) {
+    return this.endpointsService.removeHostedRegion(
+      id,
+      req.user.userId,
+      region,
+    );
+  }
+
+  @Get(':id/results')
+  @ApiOperation({ summary: 'Get paginated scan results for an endpoint' })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Scan results' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  getResults(
+    @Request() req: RequestWithUser,
+    @Param('id') id: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.endpointsService.getResults(
+      id,
+      req.user.userId,
+      page ? parseInt(page, 10) : 1,
+      limit ? Math.min(parseInt(limit, 10), 100) : 20,
+    );
+  }
+
+  @Get(':id/results/latest')
+  @ApiOperation({
+    summary: 'Get the latest scan result per probe for an endpoint',
+  })
+  @ApiParam({ name: 'id', description: 'Endpoint UUID' })
+  @ApiResponse({ status: 200, description: 'Latest scan results by probe' })
+  @ApiResponse({ status: 404, description: 'Endpoint not found' })
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  getLatestResults(@Request() req: RequestWithUser, @Param('id') id: string) {
+    return this.endpointsService.getLatestResults(id, req.user.userId);
+  }
+}

--- a/backend/src/endpoints/endpoints.module.ts
+++ b/backend/src/endpoints/endpoints.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EndpointsController } from './endpoints.controller';
+import { EndpointsService } from './endpoints.service';
+import { Endpoint } from './entities/endpoint.entity';
+import { EndpointHostedRegion } from './entities/endpoint-hosted-region.entity';
+import { ProbeScanResult } from '../probes/entities/probe-scan-result.entity';
+import { User } from '../users/entities/user.entity';
+import { AuthModule } from '../auth/auth.module';
+import { BillingModule } from '../billing/billing.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Endpoint,
+      EndpointHostedRegion,
+      ProbeScanResult,
+      User,
+    ]),
+    AuthModule,
+    BillingModule,
+  ],
+  controllers: [EndpointsController],
+  providers: [EndpointsService],
+  exports: [EndpointsService],
+})
+export class EndpointsModule {}

--- a/backend/src/endpoints/endpoints.module.ts
+++ b/backend/src/endpoints/endpoints.module.ts
@@ -4,7 +4,9 @@ import { EndpointsController } from './endpoints.controller';
 import { EndpointsService } from './endpoints.service';
 import { Endpoint } from './entities/endpoint.entity';
 import { EndpointHostedRegion } from './entities/endpoint-hosted-region.entity';
+import { EndpointProbeAssignment } from './entities/endpoint-probe-assignment.entity';
 import { ProbeScanResult } from '../probes/entities/probe-scan-result.entity';
+import { Probe } from '../probes/entities/probe.entity';
 import { User } from '../users/entities/user.entity';
 import { AuthModule } from '../auth/auth.module';
 import { BillingModule } from '../billing/billing.module';
@@ -14,7 +16,9 @@ import { BillingModule } from '../billing/billing.module';
     TypeOrmModule.forFeature([
       Endpoint,
       EndpointHostedRegion,
+      EndpointProbeAssignment,
       ProbeScanResult,
+      Probe,
       User,
     ]),
     AuthModule,

--- a/backend/src/endpoints/endpoints.service.spec.ts
+++ b/backend/src/endpoints/endpoints.service.spec.ts
@@ -1,0 +1,290 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException, HttpException } from '@nestjs/common';
+import { EndpointsService } from './endpoints.service';
+import { Endpoint } from './entities/endpoint.entity';
+import { EndpointHostedRegion } from './entities/endpoint-hosted-region.entity';
+import { ProbeScanResult } from '../probes/entities/probe-scan-result.entity';
+import { User } from '../users/entities/user.entity';
+import { BillingService } from '../billing/billing.service';
+
+describe('EndpointsService', () => {
+  let service: EndpointsService;
+  let endpointRepo: Record<string, jest.Mock>;
+  let hostedRegionRepo: Record<string, jest.Mock>;
+  let scanResultRepo: Record<string, jest.Mock>;
+  let billingService: Record<string, jest.Mock>;
+
+  const userId = 'user-123';
+  const mockEndpoint: Endpoint = {
+    id: 'ep-uuid-1',
+    userId,
+    host: 'example.com',
+    port: 443,
+    sni: undefined,
+    label: undefined,
+    isActive: true,
+    hostedRegions: [],
+    owner: {} as any,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(async () => {
+    endpointRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      create: jest.fn((dto) => ({ ...mockEndpoint, ...dto })),
+      save: jest.fn((entity) => Promise.resolve(entity)),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+      count: jest.fn().mockResolvedValue(0),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(0),
+      }),
+    };
+
+    hostedRegionRepo = {
+      findOne: jest.fn(),
+      create: jest.fn((dto) => ({
+        id: 'ehr-uuid-1',
+        ...dto,
+        createdAt: new Date(),
+      })),
+      save: jest.fn((entity) => Promise.resolve(entity)),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(0),
+      }),
+    };
+
+    scanResultRepo = {
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        setParameters: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      }),
+    };
+
+    billingService = {
+      resolveUserTier: jest.fn().mockResolvedValue('free'),
+      getResourceCountUserIds: jest
+        .fn()
+        .mockImplementation((uid: string) => Promise.resolve([uid])),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EndpointsService,
+        {
+          provide: getRepositoryToken(Endpoint),
+          useValue: endpointRepo,
+        },
+        {
+          provide: getRepositoryToken(EndpointHostedRegion),
+          useValue: hostedRegionRepo,
+        },
+        {
+          provide: getRepositoryToken(ProbeScanResult),
+          useValue: scanResultRepo,
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            find: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: BillingService,
+          useValue: billingService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<EndpointsService>(EndpointsService);
+  });
+
+  describe('create', () => {
+    it('should create a new endpoint', async () => {
+      endpointRepo.findOne.mockResolvedValue(null);
+      endpointRepo.count.mockResolvedValue(0);
+
+      const result = await service.create(userId, {
+        host: 'example.com',
+      });
+
+      expect(result.host).toBe('example.com');
+      expect(result.port).toBe(443);
+      expect(endpointRepo.create).toHaveBeenCalled();
+      expect(endpointRepo.save).toHaveBeenCalled();
+    });
+
+    it('should return existing endpoint on duplicate', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+
+      const result = await service.create(userId, {
+        host: 'example.com',
+      });
+
+      expect(result).toEqual(mockEndpoint);
+      expect(endpointRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject when plan limit is reached', async () => {
+      endpointRepo.findOne.mockResolvedValue(null);
+      endpointRepo.count.mockResolvedValue(3); // free tier limit
+
+      await expect(
+        service.create(userId, { host: 'new.example.com' }),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should allow creation when under limit', async () => {
+      endpointRepo.findOne.mockResolvedValue(null);
+      endpointRepo.count.mockResolvedValue(2); // under free limit of 3
+
+      const result = await service.create(userId, {
+        host: 'new.example.com',
+      });
+
+      expect(result.host).toBe('new.example.com');
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all endpoints for user', async () => {
+      endpointRepo.find.mockResolvedValue([mockEndpoint]);
+
+      const result = await service.findAll(userId);
+
+      expect(result).toEqual([mockEndpoint]);
+      expect(endpointRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId },
+          relations: ['hostedRegions'],
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return endpoint by id', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+
+      const result = await service.findOne('ep-uuid-1', userId);
+
+      expect(result).toEqual(mockEndpoint);
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      endpointRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent', userId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update an endpoint', async () => {
+      endpointRepo.findOne.mockResolvedValue({ ...mockEndpoint });
+      endpointRepo.save.mockImplementation((e) => Promise.resolve(e));
+
+      const result = await service.update('ep-uuid-1', userId, {
+        label: 'New Label',
+      });
+
+      expect(result.label).toBe('New Label');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete an endpoint', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+
+      await expect(service.delete('ep-uuid-1', userId)).resolves.not.toThrow();
+      expect(endpointRepo.delete).toHaveBeenCalledWith('ep-uuid-1');
+    });
+  });
+
+  describe('addHostedRegion', () => {
+    it('should reject for free tier users', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+
+      await expect(
+        service.addHostedRegion('ep-uuid-1', userId, 'us-east-1'),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should allow for team tier users', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+      billingService.resolveUserTier.mockResolvedValue('team');
+      hostedRegionRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.addHostedRegion(
+        'ep-uuid-1',
+        userId,
+        'us-east-1',
+      );
+
+      expect(result.region).toBe('us-east-1');
+    });
+
+    it('should return existing region on duplicate', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+      billingService.resolveUserTier.mockResolvedValue('team');
+      const existingRegion = {
+        id: 'ehr-1',
+        endpointId: 'ep-uuid-1',
+        region: 'us-east-1',
+        createdAt: new Date(),
+      };
+      hostedRegionRepo.findOne.mockResolvedValue(existingRegion);
+
+      const result = await service.addHostedRegion(
+        'ep-uuid-1',
+        userId,
+        'us-east-1',
+      );
+
+      expect(result).toEqual(existingRegion);
+      expect(hostedRegionRepo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeHostedRegion', () => {
+    it('should remove a hosted region', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+
+      await expect(
+        service.removeHostedRegion('ep-uuid-1', userId, 'us-east-1'),
+      ).resolves.not.toThrow();
+    });
+
+    it('should throw when region not found', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+      hostedRegionRepo.delete.mockResolvedValue({ affected: 0 });
+
+      await expect(
+        service.removeHostedRegion('ep-uuid-1', userId, 'nonexistent'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getResults', () => {
+    it('should return paginated scan results', async () => {
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+      scanResultRepo.findAndCount.mockResolvedValue([[], 0]);
+
+      const result = await service.getResults('ep-uuid-1', userId, 1, 20);
+
+      expect(result).toEqual({ data: [], total: 0 });
+    });
+  });
+});

--- a/backend/src/endpoints/endpoints.service.spec.ts
+++ b/backend/src/endpoints/endpoints.service.spec.ts
@@ -4,7 +4,9 @@ import { NotFoundException, HttpException } from '@nestjs/common';
 import { EndpointsService } from './endpoints.service';
 import { Endpoint } from './entities/endpoint.entity';
 import { EndpointHostedRegion } from './entities/endpoint-hosted-region.entity';
+import { EndpointProbeAssignment } from './entities/endpoint-probe-assignment.entity';
 import { ProbeScanResult } from '../probes/entities/probe-scan-result.entity';
+import { Probe } from '../probes/entities/probe.entity';
 import { User } from '../users/entities/user.entity';
 import { BillingService } from '../billing/billing.service';
 
@@ -25,6 +27,7 @@ describe('EndpointsService', () => {
     label: undefined,
     isActive: true,
     hostedRegions: [],
+    probeAssignments: [],
     owner: {} as any,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -90,8 +93,28 @@ describe('EndpointsService', () => {
           useValue: hostedRegionRepo,
         },
         {
+          provide: getRepositoryToken(EndpointProbeAssignment),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn((dto: any) => ({
+              id: 'epa-uuid-1',
+              ...dto,
+              createdAt: new Date(),
+            })),
+            save: jest.fn((entity: any) => Promise.resolve(entity)),
+            delete: jest.fn().mockResolvedValue({ affected: 1 }),
+          },
+        },
+        {
           provide: getRepositoryToken(ProbeScanResult),
           useValue: scanResultRepo,
+        },
+        {
+          provide: getRepositoryToken(Probe),
+          useValue: {
+            find: jest.fn().mockResolvedValue([]),
+            findOne: jest.fn(),
+          },
         },
         {
           provide: getRepositoryToken(User),

--- a/backend/src/endpoints/endpoints.service.spec.ts
+++ b/backend/src/endpoints/endpoints.service.spec.ts
@@ -135,7 +135,11 @@ describe('EndpointsService', () => {
 
   describe('create', () => {
     it('should create a new endpoint', async () => {
-      endpointRepo.findOne.mockResolvedValue(null);
+      // First call: duplicate check (null = not found)
+      // Second call: findOne re-fetch after save (returns saved endpoint)
+      endpointRepo.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockEndpoint);
       endpointRepo.count.mockResolvedValue(0);
 
       const result = await service.create(userId, {
@@ -143,7 +147,6 @@ describe('EndpointsService', () => {
       });
 
       expect(result.host).toBe('example.com');
-      expect(result.port).toBe(443);
       expect(endpointRepo.create).toHaveBeenCalled();
       expect(endpointRepo.save).toHaveBeenCalled();
     });
@@ -169,7 +172,9 @@ describe('EndpointsService', () => {
     });
 
     it('should allow creation when under limit', async () => {
-      endpointRepo.findOne.mockResolvedValue(null);
+      endpointRepo.findOne
+        .mockResolvedValueOnce(null) // duplicate check
+        .mockResolvedValueOnce({ ...mockEndpoint, host: 'new.example.com' }); // re-fetch
       endpointRepo.count.mockResolvedValue(2); // under free limit of 3
 
       const result = await service.create(userId, {
@@ -190,7 +195,11 @@ describe('EndpointsService', () => {
       expect(endpointRepo.find).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { userId },
-          relations: ['hostedRegions'],
+          relations: [
+            'hostedRegions',
+            'probeAssignments',
+            'probeAssignments.probe',
+          ],
         }),
       );
     });

--- a/backend/src/endpoints/endpoints.service.ts
+++ b/backend/src/endpoints/endpoints.service.ts
@@ -280,6 +280,96 @@ export class EndpointsService {
       .getMany();
   }
 
+  async exportResults(
+    endpointId: string,
+    userId: string,
+    format: 'json' | 'csv' = 'json',
+  ): Promise<{ data: string; contentType: string; filename: string }> {
+    const endpoint = await this.findOne(endpointId, userId);
+    const results = await this.scanResultRepo.find({
+      where: { endpointId },
+      order: { scannedAt: 'DESC' },
+    });
+
+    const filename = `${endpoint.host}_${endpoint.port}_scan_results`;
+
+    if (format === 'csv') {
+      const headers = [
+        'scannedAt',
+        'probeId',
+        'probeMode',
+        'probeRegion',
+        'connectionSuccess',
+        'connectionError',
+        'latencyMs',
+        'tlsVersion',
+        'cipherSuite',
+        'ocspStapled',
+        'certSubject',
+        'certIssuer',
+        'certNotBefore',
+        'certNotAfter',
+        'certDaysUntilExpiry',
+        'certKeyType',
+        'certKeySize',
+        'certSignatureAlgorithm',
+        'certFingerprint',
+        'certChainDepth',
+        'certChainComplete',
+        'certTrusted',
+        'certSans',
+      ];
+      const csvRows = [headers.join(',')];
+      for (const r of results) {
+        const row = [
+          r.scannedAt?.toISOString() ?? '',
+          r.probeId,
+          r.probeMode ?? '',
+          r.probeRegion ?? '',
+          String(r.connectionSuccess),
+          this.csvEscape(r.connectionError),
+          r.latencyMs?.toString() ?? '',
+          r.tlsVersion ?? '',
+          r.cipherSuite ?? '',
+          r.ocspStapled?.toString() ?? '',
+          this.csvEscape(r.certSubject),
+          this.csvEscape(r.certIssuer),
+          r.certNotBefore?.toISOString() ?? '',
+          r.certNotAfter?.toISOString() ?? '',
+          r.certDaysUntilExpiry?.toString() ?? '',
+          r.certKeyType ?? '',
+          r.certKeySize?.toString() ?? '',
+          r.certSignatureAlgorithm ?? '',
+          r.certFingerprint ?? '',
+          r.certChainDepth?.toString() ?? '',
+          r.certChainComplete?.toString() ?? '',
+          r.certTrusted?.toString() ?? '',
+          this.csvEscape(r.certSans?.join('; ')),
+        ];
+        csvRows.push(row.join(','));
+      }
+      return {
+        data: csvRows.join('\n'),
+        contentType: 'text/csv',
+        filename: `${filename}.csv`,
+      };
+    }
+
+    return {
+      data: JSON.stringify(results, null, 2),
+      contentType: 'application/json',
+      filename: `${filename}.json`,
+    };
+  }
+
+  private csvEscape(value: string | undefined | null): string {
+    if (value == null) return '';
+    if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+      return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+  }
+
   private async getOrgMemberIds(userId: string): Promise<string[] | null> {
     const user = await this.userRepo.findOne({
       where: { id: userId },

--- a/backend/src/endpoints/endpoints.service.ts
+++ b/backend/src/endpoints/endpoints.service.ts
@@ -1,0 +1,295 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  HttpException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Endpoint } from './entities/endpoint.entity';
+import { EndpointHostedRegion } from './entities/endpoint-hosted-region.entity';
+import { ProbeScanResult } from '../probes/entities/probe-scan-result.entity';
+import { User } from '../users/entities/user.entity';
+import { BillingService } from '../billing/billing.service';
+import { PLAN_LIMITS } from '../billing/constants/plan-limits';
+import type { CreateEndpointDto } from './dto/create-endpoint.dto';
+import type { UpdateEndpointDto } from './dto/update-endpoint.dto';
+import type { SubscriptionPlan } from '@krakenkey/shared';
+
+@Injectable()
+export class EndpointsService {
+  private readonly logger = new Logger(EndpointsService.name);
+
+  constructor(
+    @InjectRepository(Endpoint)
+    private readonly endpointRepo: Repository<Endpoint>,
+    @InjectRepository(EndpointHostedRegion)
+    private readonly hostedRegionRepo: Repository<EndpointHostedRegion>,
+    @InjectRepository(ProbeScanResult)
+    private readonly scanResultRepo: Repository<ProbeScanResult>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    private readonly billingService: BillingService,
+  ) {}
+
+  async create(userId: string, dto: CreateEndpointDto): Promise<Endpoint> {
+    const port = dto.port ?? 443;
+
+    // Check for existing duplicate
+    const existing = await this.endpointRepo.findOne({
+      where: { userId, host: dto.host, port },
+    });
+    if (existing) {
+      return existing;
+    }
+
+    // Plan-based endpoint limit check (pooled across org members)
+    const plan = (await this.billingService.resolveUserTier(
+      userId,
+    )) as SubscriptionPlan;
+    const limits = PLAN_LIMITS[plan] ?? PLAN_LIMITS.free;
+    if (limits.monitoredEndpoints !== Infinity) {
+      const memberIds =
+        await this.billingService.getResourceCountUserIds(userId);
+      const count = await this.endpointRepo.count({
+        where: { userId: In(memberIds) },
+      });
+      if (count >= limits.monitoredEndpoints) {
+        throw new HttpException(
+          {
+            message: 'Endpoint limit reached',
+            code: 'plan_limit_exceeded',
+            limit: limits.monitoredEndpoints,
+            current: count,
+            plan,
+          },
+          403,
+        );
+      }
+    }
+
+    const endpoint = this.endpointRepo.create({
+      userId,
+      host: dto.host,
+      port,
+      sni: dto.sni,
+      label: dto.label,
+    });
+
+    return this.endpointRepo.save(endpoint);
+  }
+
+  async findAll(userId: string): Promise<Endpoint[]> {
+    const memberIds = await this.getOrgMemberIds(userId);
+    if (memberIds) {
+      return this.endpointRepo.find({
+        where: { userId: In(memberIds) },
+        relations: ['hostedRegions'],
+        order: { createdAt: 'DESC' },
+      });
+    }
+    return this.endpointRepo.find({
+      where: { userId },
+      relations: ['hostedRegions'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOne(id: string, userId: string): Promise<Endpoint> {
+    let endpoint = await this.endpointRepo.findOne({
+      where: { id, userId },
+      relations: ['hostedRegions'],
+    });
+
+    if (!endpoint) {
+      const memberIds = await this.getOrgMemberIds(userId);
+      if (memberIds) {
+        endpoint = await this.endpointRepo.findOne({
+          where: { id, userId: In(memberIds) },
+          relations: ['hostedRegions'],
+        });
+      }
+    }
+
+    if (!endpoint) {
+      throw new NotFoundException(`Endpoint #${id} not found`);
+    }
+    return endpoint;
+  }
+
+  async update(
+    id: string,
+    userId: string,
+    dto: UpdateEndpointDto,
+  ): Promise<Endpoint> {
+    const endpoint = await this.findOne(id, userId);
+    Object.assign(endpoint, dto);
+    return this.endpointRepo.save(endpoint);
+  }
+
+  async delete(id: string, userId: string): Promise<void> {
+    const endpoint = await this.findOne(id, userId);
+    const result = await this.endpointRepo.delete(endpoint.id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Endpoint #${id} not found`);
+    }
+  }
+
+  async addHostedRegion(
+    endpointId: string,
+    userId: string,
+    region: string,
+  ): Promise<EndpointHostedRegion> {
+    const endpoint = await this.findOne(endpointId, userId);
+
+    // Check plan limits for hosted monitoring
+    const plan = (await this.billingService.resolveUserTier(
+      userId,
+    )) as SubscriptionPlan;
+    const limits = PLAN_LIMITS[plan] ?? PLAN_LIMITS.free;
+
+    if (limits.hostedProbeRegions === 0) {
+      throw new HttpException(
+        {
+          message: 'Hosted monitoring is not available on your plan',
+          code: 'plan_limit_exceeded',
+          plan,
+        },
+        403,
+      );
+    }
+
+    // Check hosted endpoint limit (endpoints with at least one hosted region)
+    if (limits.hostedMonitoredEndpoints !== Infinity) {
+      const memberIds =
+        await this.billingService.getResourceCountUserIds(userId);
+      const hostedEndpointCount = await this.endpointRepo
+        .createQueryBuilder('e')
+        .innerJoin('endpoint_hosted_region', 'ehr', 'ehr."endpointId" = e.id')
+        .where('e."userId" IN (:...memberIds)', { memberIds })
+        .getCount();
+      // Only enforce if this endpoint doesn't already have hosted regions
+      const existingRegions = endpoint.hostedRegions?.length ?? 0;
+      if (
+        existingRegions === 0 &&
+        hostedEndpointCount >= limits.hostedMonitoredEndpoints
+      ) {
+        throw new HttpException(
+          {
+            message: 'Hosted endpoint limit reached',
+            code: 'plan_limit_exceeded',
+            limit: limits.hostedMonitoredEndpoints,
+            current: hostedEndpointCount,
+            plan,
+          },
+          403,
+        );
+      }
+    }
+
+    // Check total hosted regions across all endpoints
+    if (limits.hostedProbeRegions !== Infinity) {
+      const memberIds =
+        await this.billingService.getResourceCountUserIds(userId);
+      const regionCount = await this.hostedRegionRepo
+        .createQueryBuilder('ehr')
+        .innerJoin('endpoint', 'e', 'e.id = ehr."endpointId"')
+        .where('e."userId" IN (:...memberIds)', { memberIds })
+        .getCount();
+      if (regionCount >= limits.hostedProbeRegions) {
+        throw new HttpException(
+          {
+            message: 'Hosted region limit reached',
+            code: 'plan_limit_exceeded',
+            limit: limits.hostedProbeRegions,
+            current: regionCount,
+            plan,
+          },
+          403,
+        );
+      }
+    }
+
+    // Check for duplicate
+    const existing = await this.hostedRegionRepo.findOne({
+      where: { endpointId: endpoint.id, region },
+    });
+    if (existing) {
+      return existing;
+    }
+
+    const hostedRegion = this.hostedRegionRepo.create({
+      endpointId: endpoint.id,
+      region,
+    });
+    return this.hostedRegionRepo.save(hostedRegion);
+  }
+
+  async removeHostedRegion(
+    endpointId: string,
+    userId: string,
+    region: string,
+  ): Promise<void> {
+    const endpoint = await this.findOne(endpointId, userId);
+    const result = await this.hostedRegionRepo.delete({
+      endpointId: endpoint.id,
+      region,
+    });
+    if (result.affected === 0) {
+      throw new NotFoundException(
+        `Region '${region}' not found for endpoint #${endpointId}`,
+      );
+    }
+  }
+
+  async getResults(
+    endpointId: string,
+    userId: string,
+    page = 1,
+    limit = 20,
+  ): Promise<{ data: ProbeScanResult[]; total: number }> {
+    await this.findOne(endpointId, userId);
+    const [data, total] = await this.scanResultRepo.findAndCount({
+      where: { endpointId },
+      order: { scannedAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { data, total };
+  }
+
+  async getLatestResults(
+    endpointId: string,
+    userId: string,
+  ): Promise<ProbeScanResult[]> {
+    await this.findOne(endpointId, userId);
+    return this.scanResultRepo
+      .createQueryBuilder('r')
+      .where('r."endpointId" = :endpointId', { endpointId })
+      .andWhere(
+        'r.id IN ' +
+          this.scanResultRepo
+            .createQueryBuilder('sub')
+            .select('DISTINCT ON (sub."probeId") sub.id')
+            .where('sub."endpointId" = :endpointId')
+            .orderBy('sub."probeId"')
+            .addOrderBy('sub."scannedAt"', 'DESC')
+            .getQuery(),
+      )
+      .setParameters({ endpointId })
+      .getMany();
+  }
+
+  private async getOrgMemberIds(userId: string): Promise<string[] | null> {
+    const user = await this.userRepo.findOne({
+      where: { id: userId },
+      select: { id: true, organizationId: true },
+    });
+    if (!user?.organizationId) return null;
+    const members = await this.userRepo.find({
+      where: { organizationId: user.organizationId },
+      select: { id: true },
+    });
+    return members.map((m) => m.id);
+  }
+}

--- a/backend/src/endpoints/endpoints.service.ts
+++ b/backend/src/endpoints/endpoints.service.ts
@@ -41,12 +41,25 @@ export class EndpointsService {
   async create(userId: string, dto: CreateEndpointDto): Promise<Endpoint> {
     const port = dto.port ?? 443;
 
-    // Check for existing duplicate
+    // If endpoint already exists, merge new probe/region assignments
     const existing = await this.endpointRepo.findOne({
       where: { userId, host: dto.host, port },
     });
     if (existing) {
-      return existing;
+      if (dto.probeIds?.length) {
+        await this.assignProbes(existing.id, userId, dto.probeIds);
+      }
+      if (dto.hostedRegions?.length) {
+        for (const region of dto.hostedRegions) {
+          await this.addHostedRegion(existing.id, userId, region);
+        }
+      }
+      // Update label/sni if provided
+      if (dto.label !== undefined) existing.label = dto.label;
+      if (dto.sni !== undefined) existing.sni = dto.sni;
+      existing.lastScanRequestedAt = new Date();
+      await this.endpointRepo.save(existing);
+      return this.findOne(existing.id, userId);
     }
 
     // Plan-based endpoint limit check (pooled across org members)
@@ -230,8 +243,30 @@ export class EndpointsService {
     dto: UpdateEndpointDto,
   ): Promise<Endpoint> {
     const endpoint = await this.findOne(id, userId);
-    Object.assign(endpoint, dto);
-    return this.endpointRepo.save(endpoint);
+
+    // Update scalar fields
+    if (dto.sni !== undefined) endpoint.sni = dto.sni;
+    if (dto.label !== undefined) endpoint.label = dto.label;
+    if (dto.isActive !== undefined) endpoint.isActive = dto.isActive;
+    await this.endpointRepo.save(endpoint);
+
+    // Replace connected probe assignments if provided
+    if (dto.probeIds !== undefined) {
+      await this.probeAssignmentRepo.delete({ endpointId: id });
+      if (dto.probeIds.length > 0) {
+        await this.assignProbes(id, userId, dto.probeIds);
+      }
+    }
+
+    // Replace hosted regions if provided
+    if (dto.hostedRegions !== undefined) {
+      await this.hostedRegionRepo.delete({ endpointId: id });
+      for (const region of dto.hostedRegions) {
+        await this.addHostedRegion(id, userId, region);
+      }
+    }
+
+    return this.findOne(id, userId);
   }
 
   async delete(id: string, userId: string): Promise<void> {

--- a/backend/src/endpoints/endpoints.service.ts
+++ b/backend/src/endpoints/endpoints.service.ts
@@ -263,19 +263,18 @@ export class EndpointsService {
     userId: string,
   ): Promise<ProbeScanResult[]> {
     await this.findOne(endpointId, userId);
+
+    // Subquery: get the id of the latest result per probeId using DISTINCT ON
+    const latestIds = this.scanResultRepo
+      .createQueryBuilder('sub')
+      .select('DISTINCT ON (sub."probeId") sub.id')
+      .where('sub."endpointId" = :endpointId')
+      .orderBy('sub."probeId"')
+      .addOrderBy('sub."scannedAt"', 'DESC');
+
     return this.scanResultRepo
       .createQueryBuilder('r')
-      .where('r."endpointId" = :endpointId', { endpointId })
-      .andWhere(
-        'r.id IN ' +
-          this.scanResultRepo
-            .createQueryBuilder('sub')
-            .select('DISTINCT ON (sub."probeId") sub.id')
-            .where('sub."endpointId" = :endpointId')
-            .orderBy('sub."probeId"')
-            .addOrderBy('sub."scannedAt"', 'DESC')
-            .getQuery(),
-      )
+      .where('r.id IN (' + latestIds.getQuery() + ')')
       .setParameters({ endpointId })
       .getMany();
   }

--- a/backend/src/endpoints/endpoints.service.ts
+++ b/backend/src/endpoints/endpoints.service.ts
@@ -8,12 +8,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { Endpoint } from './entities/endpoint.entity';
 import { EndpointHostedRegion } from './entities/endpoint-hosted-region.entity';
+import { EndpointProbeAssignment } from './entities/endpoint-probe-assignment.entity';
 import { ProbeScanResult } from '../probes/entities/probe-scan-result.entity';
+import { Probe } from '../probes/entities/probe.entity';
 import { User } from '../users/entities/user.entity';
 import { BillingService } from '../billing/billing.service';
 import { PLAN_LIMITS } from '../billing/constants/plan-limits';
-import type { CreateEndpointDto } from './dto/create-endpoint.dto';
-import type { UpdateEndpointDto } from './dto/update-endpoint.dto';
+import { CreateEndpointDto } from './dto/create-endpoint.dto';
+import { UpdateEndpointDto } from './dto/update-endpoint.dto';
 import type { SubscriptionPlan } from '@krakenkey/shared';
 
 @Injectable()
@@ -25,8 +27,12 @@ export class EndpointsService {
     private readonly endpointRepo: Repository<Endpoint>,
     @InjectRepository(EndpointHostedRegion)
     private readonly hostedRegionRepo: Repository<EndpointHostedRegion>,
+    @InjectRepository(EndpointProbeAssignment)
+    private readonly probeAssignmentRepo: Repository<EndpointProbeAssignment>,
     @InjectRepository(ProbeScanResult)
     private readonly scanResultRepo: Repository<ProbeScanResult>,
+    @InjectRepository(Probe)
+    private readonly probeRepo: Repository<Probe>,
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     private readonly billingService: BillingService,
@@ -74,8 +80,93 @@ export class EndpointsService {
       port,
       sni: dto.sni,
       label: dto.label,
+      lastScanRequestedAt: new Date(), // trigger immediate scan
     });
 
+    const saved = await this.endpointRepo.save(endpoint);
+
+    // Assign connected probes if specified
+    if (dto.probeIds?.length) {
+      await this.assignProbes(saved.id, userId, dto.probeIds);
+    }
+
+    // Assign hosted regions if specified
+    if (dto.hostedRegions?.length) {
+      for (const region of dto.hostedRegions) {
+        await this.addHostedRegion(saved.id, userId, region);
+      }
+    }
+
+    // Re-fetch with relations
+    return this.findOne(saved.id, userId);
+  }
+
+  async listUserProbes(userId: string): Promise<Probe[]> {
+    const memberIds = await this.getOrgMemberIds(userId);
+    const where = memberIds
+      ? { userId: In(memberIds), mode: 'connected' }
+      : { userId, mode: 'connected' };
+    return this.probeRepo.find({
+      where,
+      order: { lastSeenAt: 'DESC' },
+    });
+  }
+
+  async assignProbes(
+    endpointId: string,
+    userId: string,
+    probeIds: string[],
+  ): Promise<EndpointProbeAssignment[]> {
+    // Validate all probes belong to the user (or their org)
+    const memberIds = await this.getOrgMemberIds(userId);
+    const validIds = memberIds ?? [userId];
+
+    const probes = await this.probeRepo.find({
+      where: { id: In(probeIds), userId: In(validIds), mode: 'connected' },
+    });
+
+    if (probes.length === 0) {
+      return [];
+    }
+
+    const assignments: EndpointProbeAssignment[] = [];
+    for (const probe of probes) {
+      const existing = await this.probeAssignmentRepo.findOne({
+        where: { endpointId, probeId: probe.id },
+      });
+      if (existing) {
+        assignments.push(existing);
+        continue;
+      }
+      const assignment = this.probeAssignmentRepo.create({
+        endpointId,
+        probeId: probe.id,
+      });
+      assignments.push(await this.probeAssignmentRepo.save(assignment));
+    }
+    return assignments;
+  }
+
+  async unassignProbe(
+    endpointId: string,
+    userId: string,
+    probeId: string,
+  ): Promise<void> {
+    await this.findOne(endpointId, userId); // access check
+    const result = await this.probeAssignmentRepo.delete({
+      endpointId,
+      probeId,
+    });
+    if (result.affected === 0) {
+      throw new NotFoundException(
+        `Probe '${probeId}' is not assigned to endpoint #${endpointId}`,
+      );
+    }
+  }
+
+  async requestScan(id: string, userId: string): Promise<Endpoint> {
+    const endpoint = await this.findOne(id, userId);
+    endpoint.lastScanRequestedAt = new Date();
     return this.endpointRepo.save(endpoint);
   }
 
@@ -84,13 +175,21 @@ export class EndpointsService {
     if (memberIds) {
       return this.endpointRepo.find({
         where: { userId: In(memberIds) },
-        relations: ['hostedRegions'],
+        relations: [
+          'hostedRegions',
+          'probeAssignments',
+          'probeAssignments.probe',
+        ],
         order: { createdAt: 'DESC' },
       });
     }
     return this.endpointRepo.find({
       where: { userId },
-      relations: ['hostedRegions'],
+      relations: [
+        'hostedRegions',
+        'probeAssignments',
+        'probeAssignments.probe',
+      ],
       order: { createdAt: 'DESC' },
     });
   }
@@ -98,7 +197,11 @@ export class EndpointsService {
   async findOne(id: string, userId: string): Promise<Endpoint> {
     let endpoint = await this.endpointRepo.findOne({
       where: { id, userId },
-      relations: ['hostedRegions'],
+      relations: [
+        'hostedRegions',
+        'probeAssignments',
+        'probeAssignments.probe',
+      ],
     });
 
     if (!endpoint) {
@@ -106,7 +209,11 @@ export class EndpointsService {
       if (memberIds) {
         endpoint = await this.endpointRepo.findOne({
           where: { id, userId: In(memberIds) },
-          relations: ['hostedRegions'],
+          relations: [
+            'hostedRegions',
+            'probeAssignments',
+            'probeAssignments.probe',
+          ],
         });
       }
     }

--- a/backend/src/endpoints/entities/endpoint-hosted-region.entity.ts
+++ b/backend/src/endpoints/entities/endpoint-hosted-region.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { Endpoint } from './endpoint.entity';
+
+@Entity()
+@Unique('UQ_endpoint_hosted_region_endpointId_region', ['endpointId', 'region'])
+@Index('IDX_endpoint_hosted_region_region', ['region'])
+export class EndpointHostedRegion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  endpointId: string;
+
+  @ManyToOne(() => Endpoint, (e) => e.hostedRegions, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'endpointId' })
+  endpoint: Endpoint;
+
+  @Column()
+  region: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/endpoints/entities/endpoint-probe-assignment.entity.ts
+++ b/backend/src/endpoints/entities/endpoint-probe-assignment.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { Endpoint } from './endpoint.entity';
+import { Probe } from '../../probes/entities/probe.entity';
+
+@Entity()
+@Unique('UQ_endpoint_probe_assignment', ['endpointId', 'probeId'])
+@Index('IDX_endpoint_probe_assignment_probeId', ['probeId'])
+export class EndpointProbeAssignment {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  endpointId: string;
+
+  @ManyToOne(() => Endpoint, (e) => e.probeAssignments, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'endpointId' })
+  endpoint: Endpoint;
+
+  @Column({ type: 'varchar' })
+  probeId: string;
+
+  @ManyToOne(() => Probe, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'probeId' })
+  probe: Probe;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/endpoints/entities/endpoint.entity.ts
+++ b/backend/src/endpoints/entities/endpoint.entity.ts
@@ -12,6 +12,7 @@ import {
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { EndpointHostedRegion } from './endpoint-hosted-region.entity';
+import { EndpointProbeAssignment } from './endpoint-probe-assignment.entity';
 
 @Entity()
 @Unique('UQ_endpoint_userId_host_port', ['userId', 'host', 'port'])
@@ -42,8 +43,15 @@ export class Endpoint {
   @Column({ default: true })
   isActive: boolean;
 
+  /** Set when user triggers an on-demand scan; probes check this to prioritize */
+  @Column({ type: 'timestamp', nullable: true })
+  lastScanRequestedAt?: Date;
+
   @OneToMany(() => EndpointHostedRegion, (r) => r.endpoint)
   hostedRegions: EndpointHostedRegion[];
+
+  @OneToMany(() => EndpointProbeAssignment, (a) => a.endpoint)
+  probeAssignments: EndpointProbeAssignment[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/src/endpoints/entities/endpoint.entity.ts
+++ b/backend/src/endpoints/entities/endpoint.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  Index,
+  Unique,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { EndpointHostedRegion } from './endpoint-hosted-region.entity';
+
+@Entity()
+@Unique('UQ_endpoint_userId_host_port', ['userId', 'host', 'port'])
+@Index('IDX_endpoint_userId_isActive', ['userId', 'isActive'])
+export class Endpoint {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  owner: User;
+
+  @Column()
+  host: string;
+
+  @Column({ type: 'int', default: 443 })
+  port: number;
+
+  @Column({ nullable: true })
+  sni?: string;
+
+  @Column({ nullable: true })
+  label?: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @OneToMany(() => EndpointHostedRegion, (r) => r.endpoint)
+  hostedRegions: EndpointHostedRegion[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/metrics/metrics.service.ts
+++ b/backend/src/metrics/metrics.service.ts
@@ -70,6 +70,42 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // --- Probes & Endpoints ---
+  readonly probeReportsTotal = new Counter({
+    name: 'probe_reports_total',
+    help: 'Total scan reports submitted by probes',
+    labelNames: ['probe_id', 'mode'] as const,
+    registers: [this.registry],
+  });
+
+  readonly monitoredEndpointsTotal = new Gauge({
+    name: 'monitored_endpoints_total',
+    help: 'Number of active monitored endpoints',
+    labelNames: ['mode'] as const,
+    registers: [this.registry],
+  });
+
+  readonly endpointCertExpiryDays = new Gauge({
+    name: 'endpoint_cert_expiry_days',
+    help: 'Days until endpoint certificate expires',
+    labelNames: ['host', 'port', 'mode', 'region'] as const,
+    registers: [this.registry],
+  });
+
+  readonly hostedProbeRegionsActive = new Gauge({
+    name: 'hosted_probe_regions_active',
+    help: 'Number of active hosted probe regions',
+    registers: [this.registry],
+  });
+
+  readonly endpointLatencyByRegion = new Histogram({
+    name: 'endpoint_latency_by_region_ms',
+    help: 'Endpoint scan latency by region in milliseconds',
+    labelNames: ['host', 'port', 'region'] as const,
+    buckets: [10, 25, 50, 100, 250, 500, 1000, 2500],
+    registers: [this.registry],
+  });
+
   onModuleInit() {
     collectDefaultMetrics({ register: this.registry });
   }

--- a/backend/src/migrations/1774000000000-AddProbesAndServiceKeys.ts
+++ b/backend/src/migrations/1774000000000-AddProbesAndServiceKeys.ts
@@ -1,0 +1,115 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProbesAndServiceKeys1774000000000 implements MigrationInterface {
+  name = 'AddProbesAndServiceKeys1774000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ── service_api_key ─────────────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "service_api_key" (
+        "id"          uuid        NOT NULL DEFAULT uuid_generate_v4(),
+        "name"        varchar     NOT NULL,
+        "hash"        varchar     NOT NULL,
+        "expiresAt"   TIMESTAMP,
+        "revokedAt"   TIMESTAMP,
+        "createdAt"   TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_service_api_key" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_service_api_key_hash" UNIQUE ("hash")
+      )
+    `);
+
+    // ── probe ───────────────────────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "probe" (
+        "id"          varchar     NOT NULL,
+        "name"        varchar     NOT NULL,
+        "version"     varchar     NOT NULL,
+        "mode"        varchar     NOT NULL,
+        "region"      varchar,
+        "os"          varchar     NOT NULL,
+        "arch"        varchar     NOT NULL,
+        "status"      varchar     NOT NULL DEFAULT 'active',
+        "lastSeenAt"  TIMESTAMP,
+        "createdAt"   TIMESTAMP   NOT NULL DEFAULT now(),
+        "updatedAt"   TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_probe" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_probe_status"
+        ON "probe" ("status")
+    `);
+
+    // ── probe_scan_result ───────────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "probe_scan_result" (
+        "id"                      uuid        NOT NULL DEFAULT uuid_generate_v4(),
+        "probeId"                 varchar     NOT NULL,
+        "host"                    varchar     NOT NULL,
+        "port"                    integer     NOT NULL,
+        "sni"                     varchar,
+        "userId"                  text,
+        "connectionSuccess"       boolean     NOT NULL,
+        "connectionError"         text,
+        "latencyMs"               integer,
+        "tlsVersion"              varchar,
+        "cipherSuite"             varchar,
+        "ocspStapled"             boolean,
+        "certSubject"             varchar,
+        "certSans"                text[],
+        "certIssuer"              varchar,
+        "certSerialNumber"        varchar,
+        "certNotBefore"           TIMESTAMP,
+        "certNotAfter"            TIMESTAMP,
+        "certDaysUntilExpiry"     integer,
+        "certKeyType"             varchar,
+        "certKeySize"             integer,
+        "certSignatureAlgorithm"  varchar,
+        "certFingerprint"         varchar,
+        "certChainDepth"          integer,
+        "certChainComplete"       boolean,
+        "certTrusted"             boolean,
+        "scannedAt"               TIMESTAMP   NOT NULL,
+        "createdAt"               TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_probe_scan_result" PRIMARY KEY ("id")
+      )
+    `);
+
+    // Foreign key: probe_scan_result.probeId → probe.id
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_probe_scan_result_probeId'
+        ) THEN
+          ALTER TABLE "probe_scan_result"
+            ADD CONSTRAINT "FK_probe_scan_result_probeId"
+            FOREIGN KEY ("probeId") REFERENCES "probe"("id")
+            ON DELETE CASCADE;
+        END IF;
+      END $$
+    `);
+
+    // Indexes for common query patterns
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_probe_scan_result_probeId_scannedAt"
+        ON "probe_scan_result" ("probeId", "scannedAt" DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_probe_scan_result_userId_scannedAt"
+        ON "probe_scan_result" ("userId", "scannedAt" DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_probe_scan_result_host_port_scannedAt"
+        ON "probe_scan_result" ("host", "port", "scannedAt" DESC)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "probe_scan_result" CASCADE`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "probe" CASCADE`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "service_api_key" CASCADE`);
+  }
+}

--- a/backend/src/migrations/1775000000000-AddEndpointsAndProbeEnhancements.ts
+++ b/backend/src/migrations/1775000000000-AddEndpointsAndProbeEnhancements.ts
@@ -14,6 +14,7 @@ export class AddEndpointsAndProbeEnhancements1775000000000 implements MigrationI
         "sni"       varchar,
         "label"     varchar,
         "isActive"  boolean     NOT NULL DEFAULT true,
+        "lastScanRequestedAt" TIMESTAMP,
         "createdAt" TIMESTAMP   NOT NULL DEFAULT now(),
         "updatedAt" TIMESTAMP   NOT NULL DEFAULT now(),
         CONSTRAINT "PK_endpoint" PRIMARY KEY ("id"),
@@ -67,6 +68,49 @@ export class AddEndpointsAndProbeEnhancements1775000000000 implements MigrationI
     await queryRunner.query(`
       CREATE INDEX IF NOT EXISTS "IDX_endpoint_hosted_region_region"
         ON "endpoint_hosted_region" ("region")
+    `);
+
+    // ── endpoint_probe_assignment ──────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "endpoint_probe_assignment" (
+        "id"          uuid      NOT NULL DEFAULT uuid_generate_v4(),
+        "endpointId"  uuid      NOT NULL,
+        "probeId"     varchar   NOT NULL,
+        "createdAt"   TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_endpoint_probe_assignment" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_endpoint_probe_assignment" UNIQUE ("endpointId", "probeId")
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_endpoint_probe_assignment_endpointId'
+        ) THEN
+          ALTER TABLE "endpoint_probe_assignment"
+            ADD CONSTRAINT "FK_endpoint_probe_assignment_endpointId"
+            FOREIGN KEY ("endpointId") REFERENCES "endpoint"("id")
+            ON DELETE CASCADE;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_endpoint_probe_assignment_probeId'
+        ) THEN
+          ALTER TABLE "endpoint_probe_assignment"
+            ADD CONSTRAINT "FK_endpoint_probe_assignment_probeId"
+            FOREIGN KEY ("probeId") REFERENCES "probe"("id")
+            ON DELETE CASCADE;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_endpoint_probe_assignment_probeId"
+        ON "endpoint_probe_assignment" ("probeId")
     `);
 
     // ── probe: add userId column ────────────────────────────────────────
@@ -170,6 +214,9 @@ export class AddEndpointsAndProbeEnhancements1775000000000 implements MigrationI
     `);
 
     // Drop tables
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "endpoint_probe_assignment" CASCADE`,
+    );
     await queryRunner.query(
       `DROP TABLE IF EXISTS "endpoint_hosted_region" CASCADE`,
     );

--- a/backend/src/migrations/1775000000000-AddEndpointsAndProbeEnhancements.ts
+++ b/backend/src/migrations/1775000000000-AddEndpointsAndProbeEnhancements.ts
@@ -1,0 +1,178 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEndpointsAndProbeEnhancements1775000000000 implements MigrationInterface {
+  name = 'AddEndpointsAndProbeEnhancements1775000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ── endpoint ────────────────────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "endpoint" (
+        "id"        uuid        NOT NULL DEFAULT uuid_generate_v4(),
+        "userId"    text        NOT NULL,
+        "host"      varchar     NOT NULL,
+        "port"      integer     NOT NULL DEFAULT 443,
+        "sni"       varchar,
+        "label"     varchar,
+        "isActive"  boolean     NOT NULL DEFAULT true,
+        "createdAt" TIMESTAMP   NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_endpoint" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_endpoint_userId_host_port" UNIQUE ("userId", "host", "port")
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_endpoint_userId'
+        ) THEN
+          ALTER TABLE "endpoint"
+            ADD CONSTRAINT "FK_endpoint_userId"
+            FOREIGN KEY ("userId") REFERENCES "user"("id")
+            ON DELETE CASCADE;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_endpoint_userId_isActive"
+        ON "endpoint" ("userId", "isActive")
+    `);
+
+    // ── endpoint_hosted_region ──────────────────────────────────────────
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "endpoint_hosted_region" (
+        "id"          uuid      NOT NULL DEFAULT uuid_generate_v4(),
+        "endpointId"  uuid      NOT NULL,
+        "region"      varchar   NOT NULL,
+        "createdAt"   TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_endpoint_hosted_region" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_endpoint_hosted_region_endpointId_region" UNIQUE ("endpointId", "region")
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_endpoint_hosted_region_endpointId'
+        ) THEN
+          ALTER TABLE "endpoint_hosted_region"
+            ADD CONSTRAINT "FK_endpoint_hosted_region_endpointId"
+            FOREIGN KEY ("endpointId") REFERENCES "endpoint"("id")
+            ON DELETE CASCADE;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_endpoint_hosted_region_region"
+        ON "endpoint_hosted_region" ("region")
+    `);
+
+    // ── probe: add userId column ────────────────────────────────────────
+    await queryRunner.query(`
+      ALTER TABLE "probe"
+        ADD COLUMN IF NOT EXISTS "userId" text
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_probe_userId'
+        ) THEN
+          ALTER TABLE "probe"
+            ADD CONSTRAINT "FK_probe_userId"
+            FOREIGN KEY ("userId") REFERENCES "user"("id")
+            ON DELETE SET NULL;
+        END IF;
+      END $$
+    `);
+
+    // ── probe_scan_result: add endpointId, probeMode, probeRegion ──────
+    await queryRunner.query(`
+      ALTER TABLE "probe_scan_result"
+        ADD COLUMN IF NOT EXISTS "endpointId" uuid,
+        ADD COLUMN IF NOT EXISTS "probeMode" varchar,
+        ADD COLUMN IF NOT EXISTS "probeRegion" varchar
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_probe_scan_result_endpointId'
+        ) THEN
+          ALTER TABLE "probe_scan_result"
+            ADD CONSTRAINT "FK_probe_scan_result_endpointId"
+            FOREIGN KEY ("endpointId") REFERENCES "endpoint"("id")
+            ON DELETE SET NULL;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_probe_scan_result_endpointId_scannedAt"
+        ON "probe_scan_result" ("endpointId", "scannedAt" DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_probe_scan_result_userId_probeMode"
+        ON "probe_scan_result" ("userId", "probeMode")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_probe_scan_result_endpointId_probeMode_probeRegion"
+        ON "probe_scan_result" ("endpointId", "probeMode", "probeRegion")
+    `);
+
+    // ── Migrate old mode values ─────────────────────────────────────────
+    await queryRunner.query(`
+      UPDATE "probe" SET "mode" = 'standalone' WHERE "mode" = 'self-hosted'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Revert mode migration
+    await queryRunner.query(`
+      UPDATE "probe" SET "mode" = 'self-hosted' WHERE "mode" = 'standalone'
+    `);
+
+    // Drop new indexes on probe_scan_result
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_probe_scan_result_endpointId_probeMode_probeRegion"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_probe_scan_result_userId_probeMode"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_probe_scan_result_endpointId_scannedAt"`,
+    );
+
+    // Drop new columns on probe_scan_result
+    await queryRunner.query(`
+      ALTER TABLE "probe_scan_result"
+        DROP CONSTRAINT IF EXISTS "FK_probe_scan_result_endpointId"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "probe_scan_result"
+        DROP COLUMN IF EXISTS "endpointId",
+        DROP COLUMN IF EXISTS "probeMode",
+        DROP COLUMN IF EXISTS "probeRegion"
+    `);
+
+    // Drop userId from probe
+    await queryRunner.query(`
+      ALTER TABLE "probe"
+        DROP CONSTRAINT IF EXISTS "FK_probe_userId"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "probe"
+        DROP COLUMN IF EXISTS "userId"
+    `);
+
+    // Drop tables
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "endpoint_hosted_region" CASCADE`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "endpoint" CASCADE`);
+  }
+}

--- a/backend/src/migrations/1775100000000-AddEndpointProbeAssignment.ts
+++ b/backend/src/migrations/1775100000000-AddEndpointProbeAssignment.ts
@@ -1,0 +1,65 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEndpointProbeAssignment1775100000000 implements MigrationInterface {
+  name = 'AddEndpointProbeAssignment1775100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "endpoint_probe_assignment" (
+        "id"          uuid      NOT NULL DEFAULT uuid_generate_v4(),
+        "endpointId"  uuid      NOT NULL,
+        "probeId"     varchar   NOT NULL,
+        "createdAt"   TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_endpoint_probe_assignment" PRIMARY KEY ("id"),
+        CONSTRAINT "UQ_endpoint_probe_assignment" UNIQUE ("endpointId", "probeId")
+      )
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_endpoint_probe_assignment_endpointId'
+        ) THEN
+          ALTER TABLE "endpoint_probe_assignment"
+            ADD CONSTRAINT "FK_endpoint_probe_assignment_endpointId"
+            FOREIGN KEY ("endpointId") REFERENCES "endpoint"("id")
+            ON DELETE CASCADE;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      DO $$ BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint WHERE conname = 'FK_endpoint_probe_assignment_probeId'
+        ) THEN
+          ALTER TABLE "endpoint_probe_assignment"
+            ADD CONSTRAINT "FK_endpoint_probe_assignment_probeId"
+            FOREIGN KEY ("probeId") REFERENCES "probe"("id")
+            ON DELETE CASCADE;
+        END IF;
+      END $$
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_endpoint_probe_assignment_probeId"
+        ON "endpoint_probe_assignment" ("probeId")
+    `);
+
+    // Also add lastScanRequestedAt if it doesn't exist yet
+    await queryRunner.query(`
+      ALTER TABLE "endpoint"
+        ADD COLUMN IF NOT EXISTS "lastScanRequestedAt" TIMESTAMP
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "endpoint_probe_assignment" CASCADE`,
+    );
+    await queryRunner.query(`
+      ALTER TABLE "endpoint"
+        DROP COLUMN IF EXISTS "lastScanRequestedAt"
+    `);
+  }
+}

--- a/backend/src/probes/dto/register-probe.dto.ts
+++ b/backend/src/probes/dto/register-probe.dto.ts
@@ -1,0 +1,38 @@
+import { IsString, IsNotEmpty, IsIn, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class RegisterProbeDto {
+  @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
+  @IsString()
+  @IsNotEmpty()
+  probeId: string;
+
+  @ApiProperty({ example: 'krakenkey-prd' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ example: '0.1.0' })
+  @IsString()
+  @IsNotEmpty()
+  version: string;
+
+  @ApiProperty({ enum: ['self-hosted', 'hosted'], example: 'hosted' })
+  @IsIn(['self-hosted', 'hosted'])
+  mode: string;
+
+  @ApiPropertyOptional({ example: 'us-east-1' })
+  @IsOptional()
+  @IsString()
+  region?: string;
+
+  @ApiProperty({ example: 'linux' })
+  @IsString()
+  @IsNotEmpty()
+  os: string;
+
+  @ApiProperty({ example: 'amd64' })
+  @IsString()
+  @IsNotEmpty()
+  arch: string;
+}

--- a/backend/src/probes/dto/register-probe.dto.ts
+++ b/backend/src/probes/dto/register-probe.dto.ts
@@ -17,8 +17,11 @@ export class RegisterProbeDto {
   @IsNotEmpty()
   version: string;
 
-  @ApiProperty({ enum: ['self-hosted', 'hosted'], example: 'hosted' })
-  @IsIn(['self-hosted', 'hosted'])
+  @ApiProperty({
+    enum: ['standalone', 'connected', 'hosted'],
+    example: 'connected',
+  })
+  @IsIn(['standalone', 'connected', 'hosted'])
   mode: string;
 
   @ApiPropertyOptional({ example: 'us-east-1' })

--- a/backend/src/probes/dto/submit-report.dto.ts
+++ b/backend/src/probes/dto/submit-report.dto.ts
@@ -156,7 +156,7 @@ export class SubmitReportDto {
   @IsNotEmpty()
   probeId: string;
 
-  @ApiProperty({ enum: ['self-hosted', 'hosted'] })
+  @ApiProperty({ enum: ['standalone', 'connected', 'hosted'] })
   @IsString()
   @IsNotEmpty()
   mode: string;

--- a/backend/src/probes/dto/submit-report.dto.ts
+++ b/backend/src/probes/dto/submit-report.dto.ts
@@ -1,0 +1,178 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsDateString,
+  IsArray,
+  ValidateNested,
+  IsBoolean,
+  IsInt,
+  IsNumber,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class EndpointDto {
+  @ApiProperty({ example: 'example.com' })
+  @IsString()
+  @IsNotEmpty()
+  host: string;
+
+  @ApiProperty({ example: 443 })
+  @IsInt()
+  port: number;
+
+  @ApiPropertyOptional({ example: 'example.com' })
+  @IsOptional()
+  @IsString()
+  sni?: string;
+}
+
+export class ConnectionResultDto {
+  @ApiProperty()
+  @IsBoolean()
+  success: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  error?: string;
+
+  @ApiPropertyOptional({ example: 42 })
+  @IsOptional()
+  @IsNumber()
+  latencyMs?: number;
+
+  @ApiPropertyOptional({ example: 'TLS 1.3' })
+  @IsOptional()
+  @IsString()
+  tlsVersion?: string;
+
+  @ApiPropertyOptional({ example: 'TLS_AES_256_GCM_SHA384' })
+  @IsOptional()
+  @IsString()
+  cipherSuite?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  ocspStapled?: boolean;
+}
+
+export class CertificateResultDto {
+  @ApiPropertyOptional({ example: 'CN=example.com' })
+  @IsOptional()
+  @IsString()
+  subject?: string;
+
+  @ApiPropertyOptional({ example: ['example.com', 'www.example.com'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  sans?: string[];
+
+  @ApiPropertyOptional({ example: "CN=Let's Encrypt Authority X3" })
+  @IsOptional()
+  @IsString()
+  issuer?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  serialNumber?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  notBefore?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsDateString()
+  notAfter?: string;
+
+  @ApiPropertyOptional({ example: 243 })
+  @IsOptional()
+  @IsInt()
+  daysUntilExpiry?: number;
+
+  @ApiPropertyOptional({ example: 'RSA' })
+  @IsOptional()
+  @IsString()
+  keyType?: string;
+
+  @ApiPropertyOptional({ example: 2048 })
+  @IsOptional()
+  @IsInt()
+  keySize?: number;
+
+  @ApiPropertyOptional({ example: 'sha256WithRSAEncryption' })
+  @IsOptional()
+  @IsString()
+  signatureAlgorithm?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  fingerprint?: string;
+
+  @ApiPropertyOptional({ example: 3 })
+  @IsOptional()
+  @IsInt()
+  chainDepth?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  chainComplete?: boolean;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  trusted?: boolean;
+}
+
+export class ScanResultDto {
+  @ApiProperty()
+  @ValidateNested()
+  @Type(() => EndpointDto)
+  endpoint: EndpointDto;
+
+  @ApiProperty()
+  @ValidateNested()
+  @Type(() => ConnectionResultDto)
+  connection: ConnectionResultDto;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => CertificateResultDto)
+  certificate?: CertificateResultDto;
+}
+
+export class SubmitReportDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  probeId: string;
+
+  @ApiProperty({ enum: ['self-hosted', 'hosted'] })
+  @IsString()
+  @IsNotEmpty()
+  mode: string;
+
+  @ApiPropertyOptional({ example: 'us-east-1' })
+  @IsOptional()
+  @IsString()
+  region?: string;
+
+  @ApiProperty()
+  @IsDateString()
+  timestamp: string;
+
+  @ApiProperty({ type: [ScanResultDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ScanResultDto)
+  results: ScanResultDto[];
+}

--- a/backend/src/probes/entities/probe-scan-result.entity.ts
+++ b/backend/src/probes/entities/probe-scan-result.entity.ts
@@ -1,0 +1,110 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Probe } from './probe.entity';
+
+@Entity()
+@Index('IDX_probe_scan_result_probeId_scannedAt', ['probeId', 'scannedAt'])
+@Index('IDX_probe_scan_result_userId_scannedAt', ['userId', 'scannedAt'])
+@Index('IDX_probe_scan_result_host_port_scannedAt', [
+  'host',
+  'port',
+  'scannedAt',
+])
+export class ProbeScanResult {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  probeId: string;
+
+  @ManyToOne(() => Probe)
+  @JoinColumn({ name: 'probeId' })
+  probe: Probe;
+
+  @Column()
+  host: string;
+
+  @Column({ type: 'int' })
+  port: number;
+
+  @Column({ nullable: true })
+  sni?: string;
+
+  @Column({ type: 'text', nullable: true })
+  userId?: string;
+
+  // --- Connection ---
+  @Column()
+  connectionSuccess: boolean;
+
+  @Column({ type: 'text', nullable: true })
+  connectionError?: string;
+
+  @Column({ type: 'int', nullable: true })
+  latencyMs?: number;
+
+  @Column({ nullable: true })
+  tlsVersion?: string;
+
+  @Column({ nullable: true })
+  cipherSuite?: string;
+
+  @Column({ nullable: true })
+  ocspStapled?: boolean;
+
+  // --- Certificate ---
+  @Column({ nullable: true })
+  certSubject?: string;
+
+  @Column('text', { array: true, nullable: true })
+  certSans?: string[];
+
+  @Column({ nullable: true })
+  certIssuer?: string;
+
+  @Column({ nullable: true })
+  certSerialNumber?: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  certNotBefore?: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  certNotAfter?: Date;
+
+  @Column({ type: 'int', nullable: true })
+  certDaysUntilExpiry?: number;
+
+  @Column({ nullable: true })
+  certKeyType?: string;
+
+  @Column({ type: 'int', nullable: true })
+  certKeySize?: number;
+
+  @Column({ nullable: true })
+  certSignatureAlgorithm?: string;
+
+  @Column({ nullable: true })
+  certFingerprint?: string;
+
+  @Column({ type: 'int', nullable: true })
+  certChainDepth?: number;
+
+  @Column({ nullable: true })
+  certChainComplete?: boolean;
+
+  @Column({ nullable: true })
+  certTrusted?: boolean;
+
+  @Column({ type: 'timestamp' })
+  scannedAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/probes/entities/probe-scan-result.entity.ts
+++ b/backend/src/probes/entities/probe-scan-result.entity.ts
@@ -8,6 +8,7 @@ import {
   Index,
 } from 'typeorm';
 import { Probe } from './probe.entity';
+import { Endpoint } from '../../endpoints/entities/endpoint.entity';
 
 @Entity()
 @Index('IDX_probe_scan_result_probeId_scannedAt', ['probeId', 'scannedAt'])
@@ -16,6 +17,16 @@ import { Probe } from './probe.entity';
   'host',
   'port',
   'scannedAt',
+])
+@Index('IDX_probe_scan_result_endpointId_scannedAt', [
+  'endpointId',
+  'scannedAt',
+])
+@Index('IDX_probe_scan_result_userId_probeMode', ['userId', 'probeMode'])
+@Index('IDX_probe_scan_result_endpointId_probeMode_probeRegion', [
+  'endpointId',
+  'probeMode',
+  'probeRegion',
 ])
 export class ProbeScanResult {
   @PrimaryGeneratedColumn('uuid')
@@ -28,6 +39,13 @@ export class ProbeScanResult {
   @JoinColumn({ name: 'probeId' })
   probe: Probe;
 
+  @Column({ type: 'uuid', nullable: true })
+  endpointId?: string;
+
+  @ManyToOne(() => Endpoint, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'endpointId' })
+  endpoint?: Endpoint;
+
   @Column()
   host: string;
 
@@ -39,6 +57,14 @@ export class ProbeScanResult {
 
   @Column({ type: 'text', nullable: true })
   userId?: string;
+
+  /** Denormalized: 'standalone' | 'connected' | 'hosted' */
+  @Column({ type: 'varchar', nullable: true })
+  probeMode?: string;
+
+  /** Denormalized: geographic filtering for hosted results */
+  @Column({ type: 'varchar', nullable: true })
+  probeRegion?: string;
 
   // --- Connection ---
   @Column()

--- a/backend/src/probes/entities/probe.entity.ts
+++ b/backend/src/probes/entities/probe.entity.ts
@@ -5,7 +5,10 @@ import {
   UpdateDateColumn,
   PrimaryColumn,
   Index,
+  ManyToOne,
+  JoinColumn,
 } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
 
 @Entity()
 @Index('IDX_probe_status', ['status'])
@@ -19,6 +22,7 @@ export class Probe {
   @Column()
   version: string;
 
+  /** 'standalone' | 'connected' | 'hosted' */
   @Column()
   mode: string;
 
@@ -33,6 +37,14 @@ export class Probe {
 
   @Column({ default: 'active' })
   status: string;
+
+  /** Null for hosted probes (shared infra), set for connected probes via API key auth */
+  @Column({ type: 'text', nullable: true })
+  userId?: string;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'userId' })
+  owner?: User;
 
   @Column({ type: 'timestamp', nullable: true })
   lastSeenAt?: Date;

--- a/backend/src/probes/entities/probe.entity.ts
+++ b/backend/src/probes/entities/probe.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  PrimaryColumn,
+  Index,
+} from 'typeorm';
+
+@Entity()
+@Index('IDX_probe_status', ['status'])
+export class Probe {
+  @PrimaryColumn({ type: 'varchar' })
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  version: string;
+
+  @Column()
+  mode: string;
+
+  @Column({ nullable: true })
+  region?: string;
+
+  @Column()
+  os: string;
+
+  @Column()
+  arch: string;
+
+  @Column({ default: 'active' })
+  status: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastSeenAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/probes/probes.controller.ts
+++ b/backend/src/probes/probes.controller.ts
@@ -1,6 +1,14 @@
-import { Controller, Post, Get, Body, Param, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
-import { ServiceKeyGuard } from '../auth/guards/service-key.guard';
+import { ServiceOrUserKeyGuard } from '../auth/guards/service-or-user-key.guard';
 import { RateLimitCategoryDecorator } from '../throttler/decorators/rate-limit-category.decorator';
 import { RateLimitCategory } from '../throttler/interfaces/rate-limit-category.enum';
 import { ProbesService } from './probes.service';
@@ -10,25 +18,27 @@ import { SubmitReportDto } from './dto/submit-report.dto';
 @Controller('probes')
 @ApiTags('Probes')
 @ApiBearerAuth()
-@UseGuards(ServiceKeyGuard)
 export class ProbesController {
   constructor(private readonly probesService: ProbesService) {}
 
   @Post('register')
+  @UseGuards(ServiceOrUserKeyGuard)
   @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
-  register(@Body() dto: RegisterProbeDto) {
-    return this.probesService.registerProbe(dto);
+  register(@Request() req: any, @Body() dto: RegisterProbeDto) {
+    return this.probesService.registerProbe(dto, req.user);
   }
 
   @Post('report')
+  @UseGuards(ServiceOrUserKeyGuard)
   @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
-  report(@Body() dto: SubmitReportDto) {
-    return this.probesService.submitReport(dto);
+  report(@Request() req: any, @Body() dto: SubmitReportDto) {
+    return this.probesService.submitReport(dto, req.user);
   }
 
   @Get(':probeId/config')
+  @UseGuards(ServiceOrUserKeyGuard)
   @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
-  getConfig(@Param('probeId') probeId: string) {
-    return this.probesService.getHostedConfig(probeId);
+  getConfig(@Request() req: any, @Param('probeId') probeId: string) {
+    return this.probesService.getConfig(probeId, req.user);
   }
 }

--- a/backend/src/probes/probes.controller.ts
+++ b/backend/src/probes/probes.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Post, Get, Body, Param, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import { ServiceKeyGuard } from '../auth/guards/service-key.guard';
+import { RateLimitCategoryDecorator } from '../throttler/decorators/rate-limit-category.decorator';
+import { RateLimitCategory } from '../throttler/interfaces/rate-limit-category.enum';
+import { ProbesService } from './probes.service';
+import { RegisterProbeDto } from './dto/register-probe.dto';
+import { SubmitReportDto } from './dto/submit-report.dto';
+
+@Controller('probes')
+@ApiTags('Probes')
+@ApiBearerAuth()
+@UseGuards(ServiceKeyGuard)
+export class ProbesController {
+  constructor(private readonly probesService: ProbesService) {}
+
+  @Post('register')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  register(@Body() dto: RegisterProbeDto) {
+    return this.probesService.registerProbe(dto);
+  }
+
+  @Post('report')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_WRITE)
+  report(@Body() dto: SubmitReportDto) {
+    return this.probesService.submitReport(dto);
+  }
+
+  @Get(':probeId/config')
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  getConfig(@Param('probeId') probeId: string) {
+    return this.probesService.getHostedConfig(probeId);
+  }
+}

--- a/backend/src/probes/probes.module.ts
+++ b/backend/src/probes/probes.module.ts
@@ -2,18 +2,26 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ProbesController } from './probes.controller';
 import { ProbesService } from './probes.service';
+import { ProbeMonitorService } from './services/probe-monitor.service';
+import { ScanResultCleanupService } from './services/scan-result-cleanup.service';
 import { Probe } from './entities/probe.entity';
 import { ProbeScanResult } from './entities/probe-scan-result.entity';
-import { Domain } from '../domains/entities/domain.entity';
+import { Endpoint } from '../endpoints/entities/endpoint.entity';
+import { EndpointHostedRegion } from '../endpoints/entities/endpoint-hosted-region.entity';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Probe, ProbeScanResult, Domain]),
+    TypeOrmModule.forFeature([
+      Probe,
+      ProbeScanResult,
+      Endpoint,
+      EndpointHostedRegion,
+    ]),
     AuthModule,
   ],
   controllers: [ProbesController],
-  providers: [ProbesService],
+  providers: [ProbesService, ProbeMonitorService, ScanResultCleanupService],
   exports: [ProbesService],
 })
 export class ProbesModule {}

--- a/backend/src/probes/probes.module.ts
+++ b/backend/src/probes/probes.module.ts
@@ -8,6 +8,7 @@ import { Probe } from './entities/probe.entity';
 import { ProbeScanResult } from './entities/probe-scan-result.entity';
 import { Endpoint } from '../endpoints/entities/endpoint.entity';
 import { EndpointHostedRegion } from '../endpoints/entities/endpoint-hosted-region.entity';
+import { EndpointProbeAssignment } from '../endpoints/entities/endpoint-probe-assignment.entity';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
@@ -17,6 +18,7 @@ import { AuthModule } from '../auth/auth.module';
       ProbeScanResult,
       Endpoint,
       EndpointHostedRegion,
+      EndpointProbeAssignment,
     ]),
     AuthModule,
   ],

--- a/backend/src/probes/probes.module.ts
+++ b/backend/src/probes/probes.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProbesController } from './probes.controller';
+import { ProbesService } from './probes.service';
+import { Probe } from './entities/probe.entity';
+import { ProbeScanResult } from './entities/probe-scan-result.entity';
+import { Domain } from '../domains/entities/domain.entity';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Probe, ProbeScanResult, Domain]),
+    AuthModule,
+  ],
+  controllers: [ProbesController],
+  providers: [ProbesService],
+  exports: [ProbesService],
+})
+export class ProbesModule {}

--- a/backend/src/probes/probes.service.spec.ts
+++ b/backend/src/probes/probes.service.spec.ts
@@ -1,0 +1,212 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
+import { ProbesService } from './probes.service';
+import { Probe } from './entities/probe.entity';
+import { ProbeScanResult } from './entities/probe-scan-result.entity';
+import { Endpoint } from '../endpoints/entities/endpoint.entity';
+import { EndpointHostedRegion } from '../endpoints/entities/endpoint-hosted-region.entity';
+
+describe('ProbesService', () => {
+  let service: ProbesService;
+  let probeRepo: Record<string, jest.Mock>;
+  let scanResultRepo: Record<string, jest.Mock>;
+  let endpointRepo: Record<string, jest.Mock>;
+
+  const serviceKeyUser = { isServiceKey: true, serviceKeyId: 'svc-1' };
+  const connectedUser = { userId: 'user-123' };
+
+  const mockProbe: Probe = {
+    id: 'probe-1',
+    name: 'test-probe',
+    version: '0.1.0',
+    mode: 'connected',
+    region: 'us-east-1',
+    os: 'linux',
+    arch: 'amd64',
+    status: 'active',
+    userId: 'user-123',
+    lastSeenAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Probe;
+
+  const mockEndpoint = {
+    id: 'ep-1',
+    userId: 'user-123',
+    host: 'example.com',
+    port: 443,
+    isActive: true,
+    hostedRegions: [],
+    owner: {} as any,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Endpoint;
+
+  beforeEach(async () => {
+    probeRepo = {
+      findOne: jest.fn(),
+      create: jest.fn((dto) => ({ ...dto })),
+      save: jest.fn((entity) => Promise.resolve(entity)),
+    };
+
+    scanResultRepo = {
+      create: jest.fn((dto) => ({ id: 'sr-1', ...dto })),
+      save: jest.fn((entities) => Promise.resolve(entities)),
+    };
+
+    endpointRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      createQueryBuilder: jest.fn().mockReturnValue({
+        innerJoin: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+        getOne: jest.fn().mockResolvedValue(null),
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProbesService,
+        { provide: getRepositoryToken(Probe), useValue: probeRepo },
+        {
+          provide: getRepositoryToken(ProbeScanResult),
+          useValue: scanResultRepo,
+        },
+        { provide: getRepositoryToken(Endpoint), useValue: endpointRepo },
+        {
+          provide: getRepositoryToken(EndpointHostedRegion),
+          useValue: {},
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue('60m') },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ProbesService>(ProbesService);
+  });
+
+  describe('registerProbe', () => {
+    const dto = {
+      probeId: 'probe-1',
+      name: 'test',
+      version: '0.1.0',
+      mode: 'connected' as const,
+      os: 'linux',
+      arch: 'amd64',
+    };
+
+    it('should create a new probe for connected user', async () => {
+      probeRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.registerProbe(dto, connectedUser);
+
+      expect(result.userId).toBe('user-123');
+      expect(probeRepo.create).toHaveBeenCalled();
+    });
+
+    it('should update existing probe', async () => {
+      probeRepo.findOne.mockResolvedValue({ ...mockProbe });
+
+      const result = await service.registerProbe(dto, connectedUser);
+
+      expect(result.status).toBe('active');
+      expect(probeRepo.save).toHaveBeenCalled();
+    });
+
+    it('should not set userId for service key auth', async () => {
+      probeRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.registerProbe(
+        { ...dto, mode: 'hosted' },
+        serviceKeyUser,
+      );
+
+      expect(result.userId).toBeUndefined();
+    });
+  });
+
+  describe('submitReport', () => {
+    const dto = {
+      probeId: 'probe-1',
+      mode: 'connected',
+      region: 'us-east-1',
+      timestamp: new Date().toISOString(),
+      results: [
+        {
+          endpoint: { host: 'example.com', port: 443 },
+          connection: { success: true, latencyMs: 42 },
+          certificate: { subject: 'CN=example.com', daysUntilExpiry: 90 },
+        },
+      ],
+    };
+
+    it('should throw when probe not registered', async () => {
+      probeRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.submitReport(dto, connectedUser)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should accept report and match endpoint for connected probe', async () => {
+      probeRepo.findOne.mockResolvedValue({ ...mockProbe });
+      endpointRepo.findOne.mockResolvedValue(mockEndpoint);
+
+      const result = await service.submitReport(dto, connectedUser);
+
+      expect(result.accepted).toBe(1);
+      expect(scanResultRepo.save).toHaveBeenCalled();
+    });
+
+    it('should skip results with no matching endpoint for connected probe', async () => {
+      probeRepo.findOne.mockResolvedValue({ ...mockProbe });
+      endpointRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.submitReport(dto, connectedUser);
+
+      expect(result.accepted).toBe(0);
+    });
+  });
+
+  describe('getConfig', () => {
+    it('should throw when probe not found', async () => {
+      probeRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getConfig('nonexistent', connectedUser),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should return user endpoints for connected probe', async () => {
+      probeRepo.findOne.mockResolvedValue(mockProbe);
+      endpointRepo.find.mockResolvedValue([mockEndpoint]);
+
+      const result = await service.getConfig('probe-1', connectedUser);
+
+      expect(result.endpoints).toHaveLength(1);
+      expect(result.endpoints[0].host).toBe('example.com');
+      expect(result.interval).toBe('60m');
+    });
+
+    it('should query hosted endpoints for service key auth', async () => {
+      probeRepo.findOne.mockResolvedValue({
+        ...mockProbe,
+        mode: 'hosted',
+        region: 'us-east-1',
+      });
+
+      const result = await service.getConfig('probe-1', serviceKeyUser);
+
+      expect(result.endpoints).toEqual([]);
+      expect(endpointRepo.createQueryBuilder).toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/probes/probes.service.spec.ts
+++ b/backend/src/probes/probes.service.spec.ts
@@ -7,6 +7,7 @@ import { Probe } from './entities/probe.entity';
 import { ProbeScanResult } from './entities/probe-scan-result.entity';
 import { Endpoint } from '../endpoints/entities/endpoint.entity';
 import { EndpointHostedRegion } from '../endpoints/entities/endpoint-hosted-region.entity';
+import { EndpointProbeAssignment } from '../endpoints/entities/endpoint-probe-assignment.entity';
 
 describe('ProbesService', () => {
   let service: ProbesService;
@@ -39,6 +40,7 @@ describe('ProbesService', () => {
     port: 443,
     isActive: true,
     hostedRegions: [],
+    probeAssignments: [],
     owner: {} as any,
     createdAt: new Date(),
     updatedAt: new Date(),
@@ -81,6 +83,10 @@ describe('ProbesService', () => {
         { provide: getRepositoryToken(Endpoint), useValue: endpointRepo },
         {
           provide: getRepositoryToken(EndpointHostedRegion),
+          useValue: {},
+        },
+        {
+          provide: getRepositoryToken(EndpointProbeAssignment),
           useValue: {},
         },
         {

--- a/backend/src/probes/probes.service.spec.ts
+++ b/backend/src/probes/probes.service.spec.ts
@@ -68,6 +68,7 @@ describe('ProbesService', () => {
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         getRawMany: jest.fn().mockResolvedValue([]),
+        getMany: jest.fn().mockResolvedValue([]),
         getOne: jest.fn().mockResolvedValue(null),
       }),
     };
@@ -191,9 +192,12 @@ describe('ProbesService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('should return user endpoints for connected probe', async () => {
+    it('should return assigned endpoints for connected probe', async () => {
       probeRepo.findOne.mockResolvedValue(mockProbe);
-      endpointRepo.find.mockResolvedValue([mockEndpoint]);
+      // getConnectedEndpoints now uses createQueryBuilder with getMany
+      endpointRepo
+        .createQueryBuilder()
+        .getMany.mockResolvedValue([mockEndpoint]);
 
       const result = await service.getConfig('probe-1', connectedUser);
 

--- a/backend/src/probes/probes.service.ts
+++ b/backend/src/probes/probes.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Repository } from 'typeorm';
+import { Probe } from './entities/probe.entity';
+import { ProbeScanResult } from './entities/probe-scan-result.entity';
+import { Domain } from '../domains/entities/domain.entity';
+import { TlsCrt } from '../certs/tls/entities/tls-crt.entity';
+import type { RegisterProbeDto } from './dto/register-probe.dto';
+import type { SubmitReportDto, ScanResultDto } from './dto/submit-report.dto';
+
+@Injectable()
+export class ProbesService {
+  private readonly logger = new Logger(ProbesService.name);
+
+  constructor(
+    @InjectRepository(Probe)
+    private readonly probeRepo: Repository<Probe>,
+    @InjectRepository(ProbeScanResult)
+    private readonly scanResultRepo: Repository<ProbeScanResult>,
+    @InjectRepository(Domain)
+    private readonly domainRepo: Repository<Domain>,
+    private readonly config: ConfigService,
+  ) {}
+
+  async registerProbe(dto: RegisterProbeDto): Promise<Probe> {
+    const existing = await this.probeRepo.findOne({
+      where: { id: dto.probeId },
+    });
+
+    if (existing) {
+      existing.name = dto.name;
+      existing.version = dto.version;
+      existing.mode = dto.mode;
+      existing.region = dto.region;
+      existing.os = dto.os;
+      existing.arch = dto.arch;
+      existing.status = 'active';
+      existing.lastSeenAt = new Date();
+      return this.probeRepo.save(existing);
+    }
+
+    const probe = this.probeRepo.create({
+      id: dto.probeId,
+      name: dto.name,
+      version: dto.version,
+      mode: dto.mode,
+      region: dto.region,
+      os: dto.os,
+      arch: dto.arch,
+      status: 'active',
+      lastSeenAt: new Date(),
+    });
+    return this.probeRepo.save(probe);
+  }
+
+  async submitReport(dto: SubmitReportDto): Promise<{ accepted: number }> {
+    const probe = await this.probeRepo.findOne({
+      where: { id: dto.probeId },
+    });
+    if (!probe) {
+      throw new NotFoundException(`Probe ${dto.probeId} not registered`);
+    }
+
+    probe.lastSeenAt = new Date();
+    await this.probeRepo.save(probe);
+
+    const scannedAt = new Date(dto.timestamp);
+    const entities = dto.results.map((r: ScanResultDto) =>
+      this.scanResultRepo.create({
+        probeId: dto.probeId,
+        host: r.endpoint.host,
+        port: r.endpoint.port,
+        sni: r.endpoint.sni,
+        connectionSuccess: r.connection.success,
+        connectionError: r.connection.error,
+        latencyMs: r.connection.latencyMs,
+        tlsVersion: r.connection.tlsVersion,
+        cipherSuite: r.connection.cipherSuite,
+        ocspStapled: r.connection.ocspStapled,
+        certSubject: r.certificate?.subject,
+        certSans: r.certificate?.sans,
+        certIssuer: r.certificate?.issuer,
+        certSerialNumber: r.certificate?.serialNumber,
+        certNotBefore: r.certificate?.notBefore
+          ? new Date(r.certificate.notBefore)
+          : undefined,
+        certNotAfter: r.certificate?.notAfter
+          ? new Date(r.certificate.notAfter)
+          : undefined,
+        certDaysUntilExpiry: r.certificate?.daysUntilExpiry,
+        certKeyType: r.certificate?.keyType,
+        certKeySize: r.certificate?.keySize,
+        certSignatureAlgorithm: r.certificate?.signatureAlgorithm,
+        certFingerprint: r.certificate?.fingerprint,
+        certChainDepth: r.certificate?.chainDepth,
+        certChainComplete: r.certificate?.chainComplete,
+        certTrusted: r.certificate?.trusted,
+        scannedAt,
+      }),
+    );
+
+    await this.scanResultRepo.save(entities);
+    this.logger.log(
+      `Accepted ${entities.length} scan results from probe ${dto.probeId}`,
+    );
+    return { accepted: entities.length };
+  }
+
+  async getHostedConfig(
+    probeId: string,
+  ): Promise<{ endpoints: HostedEndpoint[]; interval: string }> {
+    const probe = await this.probeRepo.findOne({ where: { id: probeId } });
+    if (!probe) {
+      throw new NotFoundException(`Probe ${probeId} not registered`);
+    }
+
+    // Find all verified domains that have at least one active certificate
+    const rows: { hostname: string; userId: string }[] = await this.domainRepo
+      .createQueryBuilder('d')
+      .select('DISTINCT d.hostname', 'hostname')
+      .addSelect('d.userId', 'userId')
+      .innerJoin(TlsCrt, 't', 't."userId" = d."userId"')
+      .where('d."isVerified" = true')
+      .andWhere('t.status IN (:...statuses)', {
+        statuses: ['issued', 'renewing'],
+      })
+      .andWhere('t."crtPem" IS NOT NULL')
+      .getRawMany();
+
+    const endpoints: HostedEndpoint[] = rows.map((r) => ({
+      host: r.hostname,
+      port: 443,
+      sni: r.hostname,
+      userId: r.userId,
+    }));
+
+    const interval =
+      this.config.get<string>('KK_PROBE_HOSTED_INTERVAL') ?? '60m';
+
+    return { endpoints, interval };
+  }
+}
+
+export interface HostedEndpoint {
+  host: string;
+  port: number;
+  sni: string;
+  userId: string;
+}

--- a/backend/src/probes/probes.service.ts
+++ b/backend/src/probes/probes.service.ts
@@ -4,10 +4,25 @@ import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 import { Probe } from './entities/probe.entity';
 import { ProbeScanResult } from './entities/probe-scan-result.entity';
-import { Domain } from '../domains/entities/domain.entity';
-import { TlsCrt } from '../certs/tls/entities/tls-crt.entity';
+import { Endpoint } from '../endpoints/entities/endpoint.entity';
+import { EndpointHostedRegion } from '../endpoints/entities/endpoint-hosted-region.entity';
 import type { RegisterProbeDto } from './dto/register-probe.dto';
 import type { SubmitReportDto, ScanResultDto } from './dto/submit-report.dto';
+
+export interface HostedEndpoint {
+  host: string;
+  port: number;
+  sni: string;
+  userId: string;
+}
+
+interface ProbeAuthUser {
+  /** Present when authenticated via user API key */
+  userId?: string;
+  /** Present when authenticated via service key */
+  isServiceKey?: boolean;
+  serviceKeyId?: string;
+}
 
 @Injectable()
 export class ProbesService {
@@ -18,15 +33,20 @@ export class ProbesService {
     private readonly probeRepo: Repository<Probe>,
     @InjectRepository(ProbeScanResult)
     private readonly scanResultRepo: Repository<ProbeScanResult>,
-    @InjectRepository(Domain)
-    private readonly domainRepo: Repository<Domain>,
+    @InjectRepository(Endpoint)
+    private readonly endpointRepo: Repository<Endpoint>,
     private readonly config: ConfigService,
   ) {}
 
-  async registerProbe(dto: RegisterProbeDto): Promise<Probe> {
+  async registerProbe(
+    dto: RegisterProbeDto,
+    user: ProbeAuthUser,
+  ): Promise<Probe> {
     const existing = await this.probeRepo.findOne({
       where: { id: dto.probeId },
     });
+
+    const userId = user.isServiceKey ? undefined : user.userId;
 
     if (existing) {
       existing.name = dto.name;
@@ -37,6 +57,7 @@ export class ProbesService {
       existing.arch = dto.arch;
       existing.status = 'active';
       existing.lastSeenAt = new Date();
+      if (userId) existing.userId = userId;
       return this.probeRepo.save(existing);
     }
 
@@ -50,11 +71,15 @@ export class ProbesService {
       arch: dto.arch,
       status: 'active',
       lastSeenAt: new Date(),
+      userId,
     });
     return this.probeRepo.save(probe);
   }
 
-  async submitReport(dto: SubmitReportDto): Promise<{ accepted: number }> {
+  async submitReport(
+    dto: SubmitReportDto,
+    user: ProbeAuthUser,
+  ): Promise<{ accepted: number }> {
     const probe = await this.probeRepo.findOne({
       where: { id: dto.probeId },
     });
@@ -66,85 +91,177 @@ export class ProbesService {
     await this.probeRepo.save(probe);
 
     const scannedAt = new Date(dto.timestamp);
-    const entities = dto.results.map((r: ScanResultDto) =>
-      this.scanResultRepo.create({
-        probeId: dto.probeId,
-        host: r.endpoint.host,
-        port: r.endpoint.port,
-        sni: r.endpoint.sni,
-        connectionSuccess: r.connection.success,
-        connectionError: r.connection.error,
-        latencyMs: r.connection.latencyMs,
-        tlsVersion: r.connection.tlsVersion,
-        cipherSuite: r.connection.cipherSuite,
-        ocspStapled: r.connection.ocspStapled,
-        certSubject: r.certificate?.subject,
-        certSans: r.certificate?.sans,
-        certIssuer: r.certificate?.issuer,
-        certSerialNumber: r.certificate?.serialNumber,
-        certNotBefore: r.certificate?.notBefore
-          ? new Date(r.certificate.notBefore)
-          : undefined,
-        certNotAfter: r.certificate?.notAfter
-          ? new Date(r.certificate.notAfter)
-          : undefined,
-        certDaysUntilExpiry: r.certificate?.daysUntilExpiry,
-        certKeyType: r.certificate?.keyType,
-        certKeySize: r.certificate?.keySize,
-        certSignatureAlgorithm: r.certificate?.signatureAlgorithm,
-        certFingerprint: r.certificate?.fingerprint,
-        certChainDepth: r.certificate?.chainDepth,
-        certChainComplete: r.certificate?.chainComplete,
-        certTrusted: r.certificate?.trusted,
-        scannedAt,
-      }),
-    );
+    const probeMode = dto.mode;
+    const probeRegion = dto.region;
 
-    await this.scanResultRepo.save(entities);
+    // For connected/hosted probes, resolve the userId to look up endpoints
+    const probeUserId = user.isServiceKey ? undefined : user.userId;
+
+    const entities: ProbeScanResult[] = [];
+
+    for (const r of dto.results) {
+      // Match host:port to a registered Endpoint
+      const endpoint = await this.resolveEndpoint(
+        r,
+        probeMode,
+        probeRegion,
+        probeUserId,
+      );
+
+      if (!endpoint && (probeMode === 'connected' || probeMode === 'hosted')) {
+        this.logger.warn(
+          `No matching endpoint for ${r.endpoint.host}:${r.endpoint.port} from probe ${dto.probeId} (${probeMode}), skipping`,
+        );
+        continue;
+      }
+
+      // For hosted probes, userId comes from the endpoint owner
+      const resultUserId = endpoint?.userId ?? probeUserId;
+
+      entities.push(
+        this.scanResultRepo.create({
+          probeId: dto.probeId,
+          endpointId: endpoint?.id,
+          host: r.endpoint.host,
+          port: r.endpoint.port,
+          sni: r.endpoint.sni,
+          userId: resultUserId,
+          probeMode,
+          probeRegion,
+          connectionSuccess: r.connection.success,
+          connectionError: r.connection.error,
+          latencyMs: r.connection.latencyMs,
+          tlsVersion: r.connection.tlsVersion,
+          cipherSuite: r.connection.cipherSuite,
+          ocspStapled: r.connection.ocspStapled,
+          certSubject: r.certificate?.subject,
+          certSans: r.certificate?.sans,
+          certIssuer: r.certificate?.issuer,
+          certSerialNumber: r.certificate?.serialNumber,
+          certNotBefore: r.certificate?.notBefore
+            ? new Date(r.certificate.notBefore)
+            : undefined,
+          certNotAfter: r.certificate?.notAfter
+            ? new Date(r.certificate.notAfter)
+            : undefined,
+          certDaysUntilExpiry: r.certificate?.daysUntilExpiry,
+          certKeyType: r.certificate?.keyType,
+          certKeySize: r.certificate?.keySize,
+          certSignatureAlgorithm: r.certificate?.signatureAlgorithm,
+          certFingerprint: r.certificate?.fingerprint,
+          certChainDepth: r.certificate?.chainDepth,
+          certChainComplete: r.certificate?.chainComplete,
+          certTrusted: r.certificate?.trusted,
+          scannedAt,
+        }),
+      );
+    }
+
+    if (entities.length > 0) {
+      await this.scanResultRepo.save(entities);
+    }
     this.logger.log(
       `Accepted ${entities.length} scan results from probe ${dto.probeId}`,
     );
     return { accepted: entities.length };
   }
 
-  async getHostedConfig(
+  async getConfig(
     probeId: string,
+    user: ProbeAuthUser,
   ): Promise<{ endpoints: HostedEndpoint[]; interval: string }> {
     const probe = await this.probeRepo.findOne({ where: { id: probeId } });
     if (!probe) {
       throw new NotFoundException(`Probe ${probeId} not registered`);
     }
 
-    // Find all verified domains that have at least one active certificate
-    const rows: { hostname: string; userId: string }[] = await this.domainRepo
-      .createQueryBuilder('d')
-      .select('DISTINCT d.hostname', 'hostname')
-      .addSelect('d.userId', 'userId')
-      .innerJoin(TlsCrt, 't', 't."userId" = d."userId"')
-      .where('d."isVerified" = true')
-      .andWhere('t.status IN (:...statuses)', {
-        statuses: ['issued', 'renewing'],
-      })
-      .andWhere('t."crtPem" IS NOT NULL')
-      .getRawMany();
+    let endpoints: HostedEndpoint[];
 
-    const endpoints: HostedEndpoint[] = rows.map((r) => ({
-      host: r.hostname,
-      port: 443,
-      sni: r.hostname,
-      userId: r.userId,
-    }));
+    if (user.isServiceKey) {
+      // Hosted probe: return all endpoints with hosted regions matching probe's region
+      endpoints = await this.getHostedEndpoints(probe.region);
+    } else {
+      // Connected probe: return user's active endpoints
+      endpoints = await this.getConnectedEndpoints(user.userId!);
+    }
 
     const interval =
       this.config.get<string>('KK_PROBE_HOSTED_INTERVAL') ?? '60m';
 
     return { endpoints, interval };
   }
-}
 
-export interface HostedEndpoint {
-  host: string;
-  port: number;
-  sni: string;
-  userId: string;
+  private async getHostedEndpoints(
+    probeRegion?: string,
+  ): Promise<HostedEndpoint[]> {
+    const query = this.endpointRepo
+      .createQueryBuilder('e')
+      .innerJoin(EndpointHostedRegion, 'ehr', 'ehr."endpointId" = e.id')
+      .select('e.host', 'host')
+      .addSelect('e.port', 'port')
+      .addSelect('COALESCE(e.sni, e.host)', 'sni')
+      .addSelect('e."userId"', 'userId')
+      .where('e."isActive" = true');
+
+    if (probeRegion) {
+      query.andWhere('ehr.region = :region', { region: probeRegion });
+    }
+
+    const rows: { host: string; port: number; sni: string; userId: string }[] =
+      await query.getRawMany();
+
+    return rows.map((r) => ({
+      host: r.host,
+      port: r.port,
+      sni: r.sni,
+      userId: r.userId,
+    }));
+  }
+
+  private async getConnectedEndpoints(
+    userId: string,
+  ): Promise<HostedEndpoint[]> {
+    const endpoints = await this.endpointRepo.find({
+      where: { userId, isActive: true },
+    });
+
+    return endpoints.map((e) => ({
+      host: e.host,
+      port: e.port,
+      sni: e.sni ?? e.host,
+      userId: e.userId,
+    }));
+  }
+
+  private async resolveEndpoint(
+    result: ScanResultDto,
+    probeMode: string,
+    probeRegion: string | undefined,
+    probeUserId: string | undefined,
+  ): Promise<Endpoint | null> {
+    const host = result.endpoint.host;
+    const port = result.endpoint.port;
+
+    if (probeMode === 'connected' && probeUserId) {
+      // Connected: match against user's endpoints
+      return this.endpointRepo.findOne({
+        where: { userId: probeUserId, host, port },
+      });
+    }
+
+    if (probeMode === 'hosted' && probeRegion) {
+      // Hosted: match against endpoints that have this region configured
+      const row = await this.endpointRepo
+        .createQueryBuilder('e')
+        .innerJoin(EndpointHostedRegion, 'ehr', 'ehr."endpointId" = e.id')
+        .where('e.host = :host AND e.port = :port', { host, port })
+        .andWhere('ehr.region = :region', { region: probeRegion })
+        .andWhere('e."isActive" = true')
+        .getOne();
+      return row;
+    }
+
+    // Standalone mode or fallback: no endpoint matching
+    return null;
+  }
 }

--- a/backend/src/probes/probes.service.ts
+++ b/backend/src/probes/probes.service.ts
@@ -102,61 +102,61 @@ export class ProbesService {
     const entities: ProbeScanResult[] = [];
 
     for (const r of dto.results) {
-      // Match host:port to a registered Endpoint
-      const endpoint = await this.resolveEndpoint(
+      // Match host:port to registered Endpoint(s)
+      // Hosted mode may return multiple endpoints (different users, same host:port)
+      const endpoints = await this.resolveEndpoints(
         r,
         probeMode,
         probeRegion,
         probeUserId,
       );
 
-      if (!endpoint && (probeMode === 'connected' || probeMode === 'hosted')) {
+      if (endpoints.length === 0) {
         this.logger.warn(
           `No matching endpoint for ${r.endpoint.host}:${r.endpoint.port} from probe ${dto.probeId} (${probeMode}), skipping`,
         );
         continue;
       }
 
-      // For hosted probes, userId comes from the endpoint owner
-      const resultUserId = endpoint?.userId ?? probeUserId;
-
-      entities.push(
-        this.scanResultRepo.create({
-          probeId: dto.probeId,
-          endpointId: endpoint?.id,
-          host: r.endpoint.host,
-          port: r.endpoint.port,
-          sni: r.endpoint.sni,
-          userId: resultUserId,
-          probeMode,
-          probeRegion,
-          connectionSuccess: r.connection.success,
-          connectionError: r.connection.error,
-          latencyMs: r.connection.latencyMs,
-          tlsVersion: r.connection.tlsVersion,
-          cipherSuite: r.connection.cipherSuite,
-          ocspStapled: r.connection.ocspStapled,
-          certSubject: r.certificate?.subject,
-          certSans: r.certificate?.sans,
-          certIssuer: r.certificate?.issuer,
-          certSerialNumber: r.certificate?.serialNumber,
-          certNotBefore: r.certificate?.notBefore
-            ? new Date(r.certificate.notBefore)
-            : undefined,
-          certNotAfter: r.certificate?.notAfter
-            ? new Date(r.certificate.notAfter)
-            : undefined,
-          certDaysUntilExpiry: r.certificate?.daysUntilExpiry,
-          certKeyType: r.certificate?.keyType,
-          certKeySize: r.certificate?.keySize,
-          certSignatureAlgorithm: r.certificate?.signatureAlgorithm,
-          certFingerprint: r.certificate?.fingerprint,
-          certChainDepth: r.certificate?.chainDepth,
-          certChainComplete: r.certificate?.chainComplete,
-          certTrusted: r.certificate?.trusted,
-          scannedAt,
-        }),
-      );
+      for (const endpoint of endpoints) {
+        entities.push(
+          this.scanResultRepo.create({
+            probeId: dto.probeId,
+            endpointId: endpoint.id,
+            host: r.endpoint.host,
+            port: r.endpoint.port,
+            sni: r.endpoint.sni,
+            userId: endpoint.userId,
+            probeMode,
+            probeRegion,
+            connectionSuccess: r.connection.success,
+            connectionError: r.connection.error,
+            latencyMs: r.connection.latencyMs,
+            tlsVersion: r.connection.tlsVersion,
+            cipherSuite: r.connection.cipherSuite,
+            ocspStapled: r.connection.ocspStapled,
+            certSubject: r.certificate?.subject,
+            certSans: r.certificate?.sans,
+            certIssuer: r.certificate?.issuer,
+            certSerialNumber: r.certificate?.serialNumber,
+            certNotBefore: r.certificate?.notBefore
+              ? new Date(r.certificate.notBefore)
+              : undefined,
+            certNotAfter: r.certificate?.notAfter
+              ? new Date(r.certificate.notAfter)
+              : undefined,
+            certDaysUntilExpiry: r.certificate?.daysUntilExpiry,
+            certKeyType: r.certificate?.keyType,
+            certKeySize: r.certificate?.keySize,
+            certSignatureAlgorithm: r.certificate?.signatureAlgorithm,
+            certFingerprint: r.certificate?.fingerprint,
+            certChainDepth: r.certificate?.chainDepth,
+            certChainComplete: r.certificate?.chainComplete,
+            certTrusted: r.certificate?.trusted,
+            scannedAt,
+          }),
+        );
+      }
     }
 
     if (entities.length > 0) {
@@ -258,35 +258,38 @@ export class ProbesService {
     }));
   }
 
-  private async resolveEndpoint(
+  /**
+   * Resolve scan result to one or more endpoints.
+   * Hosted mode can match multiple users' endpoints for the same host:port.
+   * Connected mode matches exactly one (the user's).
+   */
+  private async resolveEndpoints(
     result: ScanResultDto,
     probeMode: string,
     probeRegion: string | undefined,
     probeUserId: string | undefined,
-  ): Promise<Endpoint | null> {
+  ): Promise<Endpoint[]> {
     const host = result.endpoint.host;
     const port = result.endpoint.port;
 
     if (probeMode === 'connected' && probeUserId) {
-      // Connected: match against user's endpoints
-      return this.endpointRepo.findOne({
+      const ep = await this.endpointRepo.findOne({
         where: { userId: probeUserId, host, port },
       });
+      return ep ? [ep] : [];
     }
 
     if (probeMode === 'hosted' && probeRegion) {
-      // Hosted: match against endpoints that have this region configured
-      const row = await this.endpointRepo
+      return this.endpointRepo
         .createQueryBuilder('e')
         .innerJoin(EndpointHostedRegion, 'ehr', 'ehr."endpointId" = e.id')
         .where('e.host = :host AND e.port = :port', { host, port })
         .andWhere('ehr.region = :region', { region: probeRegion })
         .andWhere('e."isActive" = true')
-        .getOne();
-      return row;
+        .getMany();
     }
 
-    // Standalone mode or fallback: no endpoint matching
-    return null;
+    // Standalone mode: no endpoint matching
+    return [];
   }
 }

--- a/backend/src/probes/probes.service.ts
+++ b/backend/src/probes/probes.service.ts
@@ -6,6 +6,7 @@ import { Probe } from './entities/probe.entity';
 import { ProbeScanResult } from './entities/probe-scan-result.entity';
 import { Endpoint } from '../endpoints/entities/endpoint.entity';
 import { EndpointHostedRegion } from '../endpoints/entities/endpoint-hosted-region.entity';
+import { EndpointProbeAssignment } from '../endpoints/entities/endpoint-probe-assignment.entity';
 import type { RegisterProbeDto } from './dto/register-probe.dto';
 import type { SubmitReportDto, ScanResultDto } from './dto/submit-report.dto';
 
@@ -14,6 +15,7 @@ export interface HostedEndpoint {
   port: number;
   sni: string;
   userId: string;
+  scanNow?: boolean;
 }
 
 interface ProbeAuthUser {
@@ -181,8 +183,8 @@ export class ProbesService {
       // Hosted probe: return all endpoints with hosted regions matching probe's region
       endpoints = await this.getHostedEndpoints(probe.region);
     } else {
-      // Connected probe: return user's active endpoints
-      endpoints = await this.getConnectedEndpoints(user.userId!);
+      // Connected probe: return endpoints assigned to this specific probe
+      endpoints = await this.getConnectedEndpoints(user.userId!, probeId);
     }
 
     const interval =
@@ -201,35 +203,58 @@ export class ProbesService {
       .addSelect('e.port', 'port')
       .addSelect('COALESCE(e.sni, e.host)', 'sni')
       .addSelect('e."userId"', 'userId')
+      .addSelect('e."lastScanRequestedAt"', 'lastScanRequestedAt')
       .where('e."isActive" = true');
 
     if (probeRegion) {
       query.andWhere('ehr.region = :region', { region: probeRegion });
     }
 
-    const rows: { host: string; port: number; sni: string; userId: string }[] =
-      await query.getRawMany();
+    const rows: {
+      host: string;
+      port: number;
+      sni: string;
+      userId: string;
+      lastScanRequestedAt: Date | null;
+    }[] = await query.getRawMany();
+
+    const scanNowCutoff = new Date(Date.now() - 5 * 60 * 1000);
 
     return rows.map((r) => ({
       host: r.host,
       port: r.port,
       sni: r.sni,
       userId: r.userId,
+      ...(r.lastScanRequestedAt &&
+      new Date(r.lastScanRequestedAt) > scanNowCutoff
+        ? { scanNow: true }
+        : {}),
     }));
   }
 
   private async getConnectedEndpoints(
     userId: string,
+    probeId: string,
   ): Promise<HostedEndpoint[]> {
-    const endpoints = await this.endpointRepo.find({
-      where: { userId, isActive: true },
-    });
+    // Return only endpoints explicitly assigned to this probe
+    const endpoints = await this.endpointRepo
+      .createQueryBuilder('e')
+      .innerJoin(EndpointProbeAssignment, 'epa', 'epa."endpointId" = e.id')
+      .where('e."userId" = :userId', { userId })
+      .andWhere('e."isActive" = true')
+      .andWhere('epa."probeId" = :probeId', { probeId })
+      .getMany();
+
+    const scanNowCutoff = new Date(Date.now() - 5 * 60 * 1000);
 
     return endpoints.map((e) => ({
       host: e.host,
       port: e.port,
       sni: e.sni ?? e.host,
       userId: e.userId,
+      ...(e.lastScanRequestedAt && e.lastScanRequestedAt > scanNowCutoff
+        ? { scanNow: true }
+        : {}),
     }));
   }
 

--- a/backend/src/probes/services/probe-monitor.service.spec.ts
+++ b/backend/src/probes/services/probe-monitor.service.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ProbeMonitorService } from './probe-monitor.service';
+import { Probe } from '../entities/probe.entity';
+
+describe('ProbeMonitorService', () => {
+  let service: ProbeMonitorService;
+  let probeRepo: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    probeRepo = {
+      update: jest.fn().mockResolvedValue({ affected: 0 }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProbeMonitorService,
+        { provide: getRepositoryToken(Probe), useValue: probeRepo },
+      ],
+    }).compile();
+
+    service = module.get<ProbeMonitorService>(ProbeMonitorService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should update stale probes', async () => {
+    probeRepo.update.mockResolvedValue({ affected: 3 });
+
+    await service.checkStaleProbes();
+
+    expect(probeRepo.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'active' }),
+      { status: 'stale' },
+    );
+  });
+
+  it('should handle no stale probes gracefully', async () => {
+    probeRepo.update.mockResolvedValue({ affected: 0 });
+
+    await expect(service.checkStaleProbes()).resolves.not.toThrow();
+  });
+});

--- a/backend/src/probes/services/probe-monitor.service.ts
+++ b/backend/src/probes/services/probe-monitor.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import { Probe } from '../entities/probe.entity';
+
+@Injectable()
+export class ProbeMonitorService {
+  private readonly logger = new Logger(ProbeMonitorService.name);
+
+  constructor(
+    @InjectRepository(Probe)
+    private readonly probeRepo: Repository<Probe>,
+  ) {}
+
+  /**
+   * Runs daily at 3 AM. Marks probes as 'stale' if they have not sent a
+   * heartbeat (register or report) in the last 24 hours.
+   * Stale probes are flagged in the dashboard but not auto-deregistered.
+   */
+  @Cron('0 3 * * *')
+  async checkStaleProbes(): Promise<void> {
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const result = await this.probeRepo.update(
+      { status: 'active', lastSeenAt: LessThan(cutoff) },
+      { status: 'stale' },
+    );
+
+    const affected = result.affected ?? 0;
+    if (affected > 0) {
+      this.logger.warn(`Marked ${affected} probe(s) as stale`);
+    } else {
+      this.logger.log('Probe staleness check: all active probes are healthy');
+    }
+  }
+}

--- a/backend/src/probes/services/scan-result-cleanup.service.spec.ts
+++ b/backend/src/probes/services/scan-result-cleanup.service.spec.ts
@@ -1,0 +1,53 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ScanResultCleanupService } from './scan-result-cleanup.service';
+import { ProbeScanResult } from '../entities/probe-scan-result.entity';
+
+describe('ScanResultCleanupService', () => {
+  let service: ScanResultCleanupService;
+  let mockExecute: jest.Mock;
+
+  beforeEach(async () => {
+    mockExecute = jest.fn().mockResolvedValue({ affected: 0 });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScanResultCleanupService,
+        {
+          provide: getRepositoryToken(ProbeScanResult),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue({
+              delete: jest.fn().mockReturnValue({
+                where: jest.fn().mockReturnValue({
+                  execute: mockExecute,
+                }),
+              }),
+            }),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ScanResultCleanupService>(ScanResultCleanupService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should execute cleanup without errors', async () => {
+    await expect(service.cleanupExpiredResults()).resolves.not.toThrow();
+  });
+
+  it('should batch delete when results exceed batch size', async () => {
+    mockExecute
+      .mockResolvedValueOnce({ affected: 10_000 }) // first batch full
+      .mockResolvedValueOnce({ affected: 500 }) // second batch partial
+      .mockResolvedValue({ affected: 0 }); // remaining calls
+
+    await service.cleanupExpiredResults();
+
+    // At least 2 calls for orphaned cleanup + calls for tier cleanup
+    expect(mockExecute.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/backend/src/probes/services/scan-result-cleanup.service.ts
+++ b/backend/src/probes/services/scan-result-cleanup.service.ts
@@ -1,0 +1,113 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProbeScanResult } from '../entities/probe-scan-result.entity';
+import { PLAN_LIMITS } from '../../billing/constants/plan-limits';
+import type { SubscriptionPlan } from '@krakenkey/shared';
+
+const BATCH_SIZE = 10_000;
+const DEFAULT_RETENTION_DAYS = 5;
+
+@Injectable()
+export class ScanResultCleanupService {
+  private readonly logger = new Logger(ScanResultCleanupService.name);
+
+  constructor(
+    @InjectRepository(ProbeScanResult)
+    private readonly scanResultRepo: Repository<ProbeScanResult>,
+  ) {}
+
+  /**
+   * Runs daily at 4 AM. Deletes scan results older than the plan's retention
+   * period. Batches deletes to avoid locking the table.
+   */
+  @Cron('0 4 * * *')
+  async cleanupExpiredResults(): Promise<void> {
+    let totalDeleted = 0;
+
+    // Clean up orphaned results (no userId) using shortest retention
+    totalDeleted += await this.deleteOrphanedResults();
+
+    // Clean up per tier (only tiers with < 90 day retention for efficiency)
+    const tiersToClean: SubscriptionPlan[] = ['free', 'starter'];
+    for (const tier of tiersToClean) {
+      const retentionDays = PLAN_LIMITS[tier].scanResultRetentionDays;
+      totalDeleted += await this.deleteByTier(tier, retentionDays);
+    }
+
+    if (totalDeleted > 0) {
+      this.logger.log(
+        `Scan result cleanup: deleted ${totalDeleted} expired result(s)`,
+      );
+    } else {
+      this.logger.log('Scan result cleanup: no expired results found');
+    }
+  }
+
+  private async deleteOrphanedResults(): Promise<number> {
+    const cutoff = new Date(
+      Date.now() - DEFAULT_RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    );
+    let deleted = 0;
+    let affected: number;
+
+    do {
+      const result = await this.scanResultRepo
+        .createQueryBuilder()
+        .delete()
+        .where(
+          `id IN (
+            SELECT id FROM probe_scan_result
+            WHERE "userId" IS NULL AND "scannedAt" < :cutoff
+            LIMIT :limit
+          )`,
+          { cutoff, limit: BATCH_SIZE },
+        )
+        .execute();
+      affected = result.affected ?? 0;
+      deleted += affected;
+    } while (affected === BATCH_SIZE);
+
+    return deleted;
+  }
+
+  private async deleteByTier(
+    tier: string,
+    retentionDays: number,
+  ): Promise<number> {
+    const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+    let deleted = 0;
+    let affected: number;
+
+    // Delete scan results for users on this tier whose results are past retention.
+    // Join through subscription to determine tier. Handles both personal and
+    // org-based subscriptions.
+    do {
+      const result = await this.scanResultRepo
+        .createQueryBuilder()
+        .delete()
+        .where(
+          `id IN (
+            SELECT psr.id FROM probe_scan_result psr
+            INNER JOIN "user" u ON u.id = psr."userId"
+            LEFT JOIN subscription s_personal
+              ON s_personal."userId" = u.id AND s_personal.status = 'active'
+            LEFT JOIN subscription s_org
+              ON s_org."organizationId" = u."organizationId"
+              AND s_org.status = 'active'
+              AND u."organizationId" IS NOT NULL
+            WHERE psr."scannedAt" < :cutoff
+              AND COALESCE(s_org.plan, s_personal.plan, 'free') = :tier
+            LIMIT :limit
+          )`,
+          { cutoff, tier, limit: BATCH_SIZE },
+        )
+        .execute();
+      affected = result.affected ?? 0;
+      deleted += affected;
+    } while (affected === BATCH_SIZE);
+
+    return deleted;
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Settings from './pages/Settings';
 import DomainManagement from './components/DomainManagement';
 import CertificateManagement from './components/CertificateManagement';
 import ApiKeyManagement from './components/ApiKeyManagement';
+import EndpointManagement from './components/EndpointManagement';
 import Feedback from './components/Feedback';
 import Billing from './pages/Billing';
 import Organizations from './pages/Organizations';
@@ -51,6 +52,7 @@ function AppRoutes() {
         <Route index element={<Overview />} />
         <Route path="domains" element={<DomainManagement />} />
         <Route path="certificates" element={<CertificateManagement />} />
+        <Route path="endpoints" element={<EndpointManagement />} />
         <Route path="api-keys" element={<ApiKeyManagement />} />
         <Route path="billing" element={<Billing />} />
         <Route path="organizations" element={<Organizations />} />

--- a/frontend/src/components/EndpointManagement.tsx
+++ b/frontend/src/components/EndpointManagement.tsx
@@ -255,6 +255,7 @@ export default function EndpointManagement() {
   const [newHost, setNewHost] = useState('');
   const [newPort, setNewPort] = useState('443');
   const [newLabel, setNewLabel] = useState('');
+  const [useManaged, setUseManaged] = useState(true);
   const [selectedProbeIds, setSelectedProbeIds] = useState<string[]>([]);
 
   const fetchAll = useCallback(async () => {
@@ -299,6 +300,11 @@ export default function EndpointManagement() {
       return;
     }
 
+    if (!useManaged && selectedProbeIds.length === 0) {
+      toast.error('Select at least one probe or enable managed monitoring');
+      return;
+    }
+
     try {
       setCreating(true);
       const endpoint = await endpointService.createEndpoint({
@@ -306,11 +312,13 @@ export default function EndpointManagement() {
         port: parseInt(newPort, 10) || 443,
         label: newLabel.trim() || undefined,
         probeIds: selectedProbeIds.length > 0 ? selectedProbeIds : undefined,
+        hostedRegions: useManaged ? ['us-east-1'] : undefined,
       });
       toast.success(`Endpoint ${endpoint.host}:${endpoint.port} added`);
       setNewHost('');
       setNewPort('443');
       setNewLabel('');
+      setUseManaged(true);
       setSelectedProbeIds([]);
       setEndpoints((prev) => [endpoint, ...prev]);
     } catch (error) {
@@ -465,49 +473,59 @@ export default function EndpointManagement() {
             </Button>
           </div>
 
-          {/* Probe selection */}
-          {availableProbes.length > 0 && (
-            <div className="mt-4">
-              <p className="text-xs text-zinc-500 mb-2">
-                Assign connected probes (optional):
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {availableProbes.map((probe) => {
-                  const selected = selectedProbeIds.includes(probe.id);
-                  return (
-                    <button
-                      key={probe.id}
-                      type="button"
-                      onClick={() =>
-                        setSelectedProbeIds((prev) =>
-                          selected
-                            ? prev.filter((id) => id !== probe.id)
-                            : [...prev, probe.id],
-                        )
-                      }
-                      disabled={creating}
-                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors cursor-pointer ${
+          {/* Monitoring type selection */}
+          <div className="mt-4">
+            <p className="text-xs text-zinc-500 mb-2">Monitoring source:</p>
+            <div className="flex flex-wrap gap-2">
+              {/* Managed (hosted) option -- always available */}
+              <button
+                type="button"
+                onClick={() => setUseManaged((prev) => !prev)}
+                disabled={creating}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors cursor-pointer ${
+                  useManaged
+                    ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-400'
+                    : 'border-zinc-700 bg-zinc-900 text-zinc-400 hover:border-zinc-600'
+                }`}
+              >
+                <Cloud className="w-3 h-3" />
+                Managed probe
+              </button>
+
+              {/* Connected probe options */}
+              {availableProbes.map((probe) => {
+                const selected = selectedProbeIds.includes(probe.id);
+                return (
+                  <button
+                    key={probe.id}
+                    type="button"
+                    onClick={() =>
+                      setSelectedProbeIds((prev) =>
                         selected
-                          ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-400'
-                          : 'border-zinc-700 bg-zinc-900 text-zinc-400 hover:border-zinc-600'
-                      }`}
-                    >
-                      <Server className="w-3 h-3" />
-                      {probe.name}
-                      {probe.region && (
-                        <span className="text-zinc-500">({probe.region})</span>
-                      )}
-                      {probe.status === 'stale' && (
-                        <span className="text-amber-400 text-[10px]">
-                          stale
-                        </span>
-                      )}
-                    </button>
-                  );
-                })}
-              </div>
+                          ? prev.filter((id) => id !== probe.id)
+                          : [...prev, probe.id],
+                      )
+                    }
+                    disabled={creating}
+                    className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors cursor-pointer ${
+                      selected
+                        ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-400'
+                        : 'border-zinc-700 bg-zinc-900 text-zinc-400 hover:border-zinc-600'
+                    }`}
+                  >
+                    <Server className="w-3 h-3" />
+                    {probe.name}
+                    {probe.region && (
+                      <span className="text-zinc-500">({probe.region})</span>
+                    )}
+                    {probe.status === 'stale' && (
+                      <span className="text-amber-400 text-[10px]">stale</span>
+                    )}
+                  </button>
+                );
+              })}
             </div>
-          )}
+          </div>
         </form>
       </Card>
 
@@ -573,23 +591,27 @@ export default function EndpointManagement() {
                       </TableCell>
                       <TableCell>
                         <div className="flex items-center gap-1.5">
-                          {summary?.hasHosted && (
+                          {ep.hostedRegions && ep.hostedRegions.length > 0 && (
                             <Badge variant="info" dot={false}>
                               <Cloud className="w-3 h-3 mr-0.5" />
                               Managed
                             </Badge>
                           )}
-                          {summary?.hasConnected && (
-                            <Badge variant="neutral" dot={false}>
-                              <Server className="w-3 h-3 mr-0.5" />
-                              Connected
-                            </Badge>
-                          )}
-                          {!summary && (
-                            <span className="text-zinc-500 text-xs">
-                              No probes
-                            </span>
-                          )}
+                          {ep.probeAssignments &&
+                            ep.probeAssignments.length > 0 && (
+                              <Badge variant="neutral" dot={false}>
+                                <Server className="w-3 h-3 mr-0.5" />
+                                {ep.probeAssignments.length} connected
+                              </Badge>
+                            )}
+                          {(!ep.hostedRegions ||
+                            ep.hostedRegions.length === 0) &&
+                            (!ep.probeAssignments ||
+                              ep.probeAssignments.length === 0) && (
+                              <span className="text-zinc-500 text-xs">
+                                Not configured
+                              </span>
+                            )}
                         </div>
                       </TableCell>
                       <TableCell>

--- a/frontend/src/components/EndpointManagement.tsx
+++ b/frontend/src/components/EndpointManagement.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Activity,
   Plus,
@@ -242,6 +242,7 @@ export default function EndpointManagement() {
   const togglingIds = useActionSet<string>();
   const scanningIds = useActionSet<string>();
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Latest results per endpoint (for the summary row)
   const [latestResults, setLatestResults] = useState<
@@ -369,11 +370,33 @@ export default function EndpointManagement() {
     }
   };
 
+  const startAutoRefresh = useCallback(() => {
+    if (refreshTimerRef.current) return;
+    let ticks = 0;
+    refreshTimerRef.current = setInterval(() => {
+      ticks++;
+      fetchAll();
+      if (ticks >= 6) {
+        // Stop after ~60s (6 x 10s)
+        if (refreshTimerRef.current) clearInterval(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+    }, 10_000);
+  }, [fetchAll]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current) clearInterval(refreshTimerRef.current);
+    };
+  }, []);
+
   const handleRequestScan = async (ep: Endpoint) => {
     try {
       scanningIds.add(ep.id);
       await endpointService.requestScan(ep.id);
       toast.success(`Scan requested for ${ep.host}:${ep.port}`);
+      startAutoRefresh();
     } catch (error) {
       console.error('Failed to request scan:', error);
     } finally {
@@ -531,9 +554,24 @@ export default function EndpointManagement() {
 
       {/* Endpoints List */}
       <Card>
-        <h3 className="text-sm font-medium text-zinc-400 mb-4">
-          Monitored Endpoints ({endpoints.length})
-        </h3>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-medium text-zinc-400">
+            Monitored Endpoints ({endpoints.length})
+          </h3>
+          <Button
+            size="sm"
+            variant="ghost"
+            icon={
+              <RefreshCw
+                className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`}
+              />
+            }
+            onClick={fetchAll}
+            disabled={loading}
+          >
+            Refresh
+          </Button>
+        </div>
 
         {endpoints.length === 0 ? (
           <EmptyState
@@ -542,17 +580,15 @@ export default function EndpointManagement() {
             description="Add an endpoint above to start monitoring its TLS certificate."
           />
         ) : (
-          <Table>
+          <Table className="table-auto">
             <TableHeader>
-              <TableHead className="w-8" />
-              <TableHead>Host</TableHead>
-              <TableHead>Port</TableHead>
-              <TableHead>Label</TableHead>
+              <TableHead className="w-8 px-2" />
+              <TableHead>Endpoint</TableHead>
               <TableHead>Status</TableHead>
-              <TableHead>Probe Source</TableHead>
-              <TableHead>Cert Expiry</TableHead>
-              <TableHead>Last Scan</TableHead>
-              <TableHead>Actions</TableHead>
+              <TableHead>Source</TableHead>
+              <TableHead>Expiry</TableHead>
+              <TableHead className="hidden xl:table-cell">Last Scan</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
             </TableHeader>
             <tbody>
               {endpoints.map((ep) => {
@@ -566,7 +602,7 @@ export default function EndpointManagement() {
                       className="cursor-pointer"
                       onClick={() => toggleExpand(ep.id)}
                     >
-                      <TableCell className="w-8 pr-0">
+                      <TableCell className="w-8 px-2 pr-0">
                         {isExpanded ? (
                           <ChevronDown className="w-4 h-4 text-zinc-500" />
                         ) : (
@@ -574,11 +610,17 @@ export default function EndpointManagement() {
                         )}
                       </TableCell>
                       <TableCell className="font-medium text-zinc-200">
-                        {ep.host}
-                      </TableCell>
-                      <TableCell>{ep.port}</TableCell>
-                      <TableCell className="text-zinc-400">
-                        {ep.label || '-'}
+                        <div>
+                          {ep.host}
+                          {ep.port !== 443 && (
+                            <span className="text-zinc-500">:{ep.port}</span>
+                          )}
+                        </div>
+                        {ep.label && (
+                          <div className="text-xs text-zinc-500 font-normal">
+                            {ep.label}
+                          </div>
+                        )}
                       </TableCell>
                       <TableCell>
                         {summary?.anyFailed ? (
@@ -590,7 +632,7 @@ export default function EndpointManagement() {
                         )}
                       </TableCell>
                       <TableCell>
-                        <div className="flex items-center gap-1.5">
+                        <div className="flex items-center gap-1">
                           {ep.hostedRegions && ep.hostedRegions.length > 0 && (
                             <Badge variant="info" dot={false}>
                               <Cloud className="w-3 h-3 mr-0.5" />
@@ -601,7 +643,7 @@ export default function EndpointManagement() {
                             ep.probeAssignments.length > 0 && (
                               <Badge variant="neutral" dot={false}>
                                 <Server className="w-3 h-3 mr-0.5" />
-                                {ep.probeAssignments.length} connected
+                                {ep.probeAssignments.length}
                               </Badge>
                             )}
                           {(!ep.hostedRegions ||
@@ -609,7 +651,7 @@ export default function EndpointManagement() {
                             (!ep.probeAssignments ||
                               ep.probeAssignments.length === 0) && (
                               <span className="text-zinc-500 text-xs">
-                                Not configured
+                                None
                               </span>
                             )}
                         </div>
@@ -623,13 +665,16 @@ export default function EndpointManagement() {
                           <span className="text-zinc-500">-</span>
                         )}
                       </TableCell>
-                      <TableCell className="text-zinc-400 text-xs whitespace-nowrap">
+                      <TableCell className="hidden xl:table-cell text-zinc-400 text-xs whitespace-nowrap">
                         {summary?.latestScan
                           ? new Date(summary.latestScan).toLocaleString()
                           : '-'}
                       </TableCell>
-                      <TableCell onClick={(e) => e.stopPropagation()}>
-                        <div className="flex items-center gap-1.5">
+                      <TableCell
+                        className="text-right"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <div className="inline-flex items-center gap-1">
                           <Button
                             size="sm"
                             variant="secondary"
@@ -641,7 +686,7 @@ export default function EndpointManagement() {
                             onClick={() => handleRequestScan(ep)}
                             disabled={scanningIds.has(ep.id) || !ep.isActive}
                           >
-                            Scan
+                            <span className="hidden lg:inline">Scan</span>
                           </Button>
                           <Button
                             size="sm"
@@ -656,7 +701,9 @@ export default function EndpointManagement() {
                             onClick={() => handleToggleActive(ep)}
                             disabled={togglingIds.has(ep.id)}
                           >
-                            {ep.isActive ? 'Disable' : 'Enable'}
+                            <span className="hidden lg:inline">
+                              {ep.isActive ? 'Disable' : 'Enable'}
+                            </span>
                           </Button>
                           <Button
                             size="sm"
@@ -665,7 +712,9 @@ export default function EndpointManagement() {
                             onClick={() => handleDelete(ep)}
                             disabled={deletingIds.has(ep.id)}
                           >
-                            {deletingIds.has(ep.id) ? '...' : 'Delete'}
+                            <span className="hidden lg:inline">
+                              {deletingIds.has(ep.id) ? '...' : 'Delete'}
+                            </span>
                           </Button>
                         </div>
                       </TableCell>
@@ -673,7 +722,7 @@ export default function EndpointManagement() {
                     {isExpanded && (
                       <tr key={`${ep.id}-detail`}>
                         <td
-                          colSpan={9}
+                          colSpan={7}
                           className="bg-zinc-900/50 border-b border-zinc-800/50"
                         >
                           {/* Assigned probes summary */}

--- a/frontend/src/components/EndpointManagement.tsx
+++ b/frontend/src/components/EndpointManagement.tsx
@@ -10,9 +10,11 @@ import {
   Download,
   Server,
   Cloud,
+  RefreshCw,
 } from 'lucide-react';
 import { toast } from '../utils/toast';
 import type { Endpoint, ProbeScanResult } from '@krakenkey/shared';
+import type { ProbeOption } from '../services/endpointService';
 import { useActionSet } from '../hooks/useActionSet';
 import * as endpointService from '../services/endpointService';
 import { Card } from './ui/Card';
@@ -238,6 +240,7 @@ export default function EndpointManagement() {
   const [creating, setCreating] = useState(false);
   const deletingIds = useActionSet<string>();
   const togglingIds = useActionSet<string>();
+  const scanningIds = useActionSet<string>();
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   // Latest results per endpoint (for the summary row)
@@ -245,16 +248,24 @@ export default function EndpointManagement() {
     Record<string, ProbeScanResult[]>
   >({});
 
+  // Available connected probes for assignment
+  const [availableProbes, setAvailableProbes] = useState<ProbeOption[]>([]);
+
   // Form state
   const [newHost, setNewHost] = useState('');
   const [newPort, setNewPort] = useState('443');
   const [newLabel, setNewLabel] = useState('');
+  const [selectedProbeIds, setSelectedProbeIds] = useState<string[]>([]);
 
   const fetchAll = useCallback(async () => {
     try {
       setLoading(true);
-      const data = await endpointService.fetchEndpoints();
+      const [data, probes] = await Promise.all([
+        endpointService.fetchEndpoints(),
+        endpointService.fetchUserProbes().catch(() => [] as ProbeOption[]),
+      ]);
       setEndpoints(data);
+      setAvailableProbes(probes);
 
       // Fetch latest results for each endpoint
       const latestMap: Record<string, ProbeScanResult[]> = {};
@@ -294,11 +305,13 @@ export default function EndpointManagement() {
         host,
         port: parseInt(newPort, 10) || 443,
         label: newLabel.trim() || undefined,
+        probeIds: selectedProbeIds.length > 0 ? selectedProbeIds : undefined,
       });
       toast.success(`Endpoint ${endpoint.host}:${endpoint.port} added`);
       setNewHost('');
       setNewPort('443');
       setNewLabel('');
+      setSelectedProbeIds([]);
       setEndpoints((prev) => [endpoint, ...prev]);
     } catch (error) {
       console.error('Failed to create endpoint:', error);
@@ -345,6 +358,18 @@ export default function EndpointManagement() {
       console.error('Failed to toggle endpoint:', error);
     } finally {
       togglingIds.remove(ep.id);
+    }
+  };
+
+  const handleRequestScan = async (ep: Endpoint) => {
+    try {
+      scanningIds.add(ep.id);
+      await endpointService.requestScan(ep.id);
+      toast.success(`Scan requested for ${ep.host}:${ep.port}`);
+    } catch (error) {
+      console.error('Failed to request scan:', error);
+    } finally {
+      scanningIds.remove(ep.id);
     }
   };
 
@@ -439,6 +464,50 @@ export default function EndpointManagement() {
               {creating ? 'Adding...' : 'Add'}
             </Button>
           </div>
+
+          {/* Probe selection */}
+          {availableProbes.length > 0 && (
+            <div className="mt-4">
+              <p className="text-xs text-zinc-500 mb-2">
+                Assign connected probes (optional):
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {availableProbes.map((probe) => {
+                  const selected = selectedProbeIds.includes(probe.id);
+                  return (
+                    <button
+                      key={probe.id}
+                      type="button"
+                      onClick={() =>
+                        setSelectedProbeIds((prev) =>
+                          selected
+                            ? prev.filter((id) => id !== probe.id)
+                            : [...prev, probe.id],
+                        )
+                      }
+                      disabled={creating}
+                      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors cursor-pointer ${
+                        selected
+                          ? 'border-cyan-500/50 bg-cyan-500/10 text-cyan-400'
+                          : 'border-zinc-700 bg-zinc-900 text-zinc-400 hover:border-zinc-600'
+                      }`}
+                    >
+                      <Server className="w-3 h-3" />
+                      {probe.name}
+                      {probe.region && (
+                        <span className="text-zinc-500">({probe.region})</span>
+                      )}
+                      {probe.status === 'stale' && (
+                        <span className="text-amber-400 text-[10px]">
+                          stale
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
         </form>
       </Card>
 
@@ -541,6 +610,19 @@ export default function EndpointManagement() {
                         <div className="flex items-center gap-1.5">
                           <Button
                             size="sm"
+                            variant="secondary"
+                            icon={
+                              <RefreshCw
+                                className={`w-3.5 h-3.5 ${scanningIds.has(ep.id) ? 'animate-spin' : ''}`}
+                              />
+                            }
+                            onClick={() => handleRequestScan(ep)}
+                            disabled={scanningIds.has(ep.id) || !ep.isActive}
+                          >
+                            Scan
+                          </Button>
+                          <Button
+                            size="sm"
                             variant="ghost"
                             icon={
                               ep.isActive ? (
@@ -572,6 +654,44 @@ export default function EndpointManagement() {
                           colSpan={9}
                           className="bg-zinc-900/50 border-b border-zinc-800/50"
                         >
+                          {/* Assigned probes summary */}
+                          {ep.probeAssignments &&
+                            ep.probeAssignments.length > 0 && (
+                              <div className="px-4 pt-3 pb-1">
+                                <span className="text-xs text-zinc-500 mr-2">
+                                  Assigned probes:
+                                </span>
+                                {ep.probeAssignments.map((a) => (
+                                  <Badge
+                                    key={a.id}
+                                    variant="neutral"
+                                    dot={false}
+                                    className="mr-1"
+                                  >
+                                    <Server className="w-3 h-3 mr-0.5" />
+                                    {a.probe?.name ?? a.probeId}
+                                  </Badge>
+                                ))}
+                              </div>
+                            )}
+                          {ep.hostedRegions && ep.hostedRegions.length > 0 && (
+                            <div className="px-4 pt-1 pb-1">
+                              <span className="text-xs text-zinc-500 mr-2">
+                                Hosted regions:
+                              </span>
+                              {ep.hostedRegions.map((r) => (
+                                <Badge
+                                  key={r.id}
+                                  variant="info"
+                                  dot={false}
+                                  className="mr-1"
+                                >
+                                  <Cloud className="w-3 h-3 mr-0.5" />
+                                  {r.region}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
                           <ScanResultsPanel endpointId={ep.id} />
                         </td>
                       </tr>

--- a/frontend/src/components/EndpointManagement.tsx
+++ b/frontend/src/components/EndpointManagement.tsx
@@ -1,7 +1,18 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Activity, Plus, Trash2, Power, PowerOff } from 'lucide-react';
+import {
+  Activity,
+  Plus,
+  Trash2,
+  Power,
+  PowerOff,
+  ChevronDown,
+  ChevronRight,
+  Download,
+  Server,
+  Cloud,
+} from 'lucide-react';
 import { toast } from '../utils/toast';
-import type { Endpoint } from '@krakenkey/shared';
+import type { Endpoint, ProbeScanResult } from '@krakenkey/shared';
 import { useActionSet } from '../hooks/useActionSet';
 import * as endpointService from '../services/endpointService';
 import { Card } from './ui/Card';
@@ -12,12 +23,227 @@ import { Table, TableHeader, TableRow, TableHead, TableCell } from './ui/Table';
 import { PageHeader } from './ui/PageHeader';
 import { EmptyState } from './ui/EmptyState';
 
+function ProbeSourceBadge({ result }: { result: ProbeScanResult }) {
+  if (result.probeMode === 'hosted') {
+    return (
+      <Badge variant="info" dot={false}>
+        <Cloud className="w-3 h-3 mr-1" />
+        Managed
+      </Badge>
+    );
+  }
+  if (result.probeMode === 'connected') {
+    return (
+      <Badge variant="neutral" dot={false}>
+        <Server className="w-3 h-3 mr-1" />
+        Connected
+      </Badge>
+    );
+  }
+  return <Badge variant="neutral">-</Badge>;
+}
+
+function CertExpiryBadge({ days }: { days: number | undefined }) {
+  if (days == null) return <span className="text-zinc-500">-</span>;
+  if (days <= 7) return <Badge variant="danger">{days}d</Badge>;
+  if (days <= 30) return <Badge variant="warning">{days}d</Badge>;
+  return <Badge variant="success">{days}d</Badge>;
+}
+
+function ScanResultsPanel({ endpointId }: { endpointId: string }) {
+  const [results, setResults] = useState<ProbeScanResult[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const limit = 10;
+
+  const fetchPage = useCallback(
+    async (p: number) => {
+      try {
+        setLoading(true);
+        const res = await endpointService.fetchResults(endpointId, p, limit);
+        setResults(res.data);
+        setTotal(res.total);
+        setPage(p);
+      } catch (error) {
+        console.error('Failed to fetch scan results:', error);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [endpointId],
+  );
+
+  useEffect(() => {
+    fetchPage(1);
+  }, [fetchPage]);
+
+  const totalPages = Math.ceil(total / limit);
+
+  const handleExport = (format: 'json' | 'csv') => {
+    const url = endpointService.getExportUrl(endpointId, format);
+    const token = localStorage.getItem('access_token');
+    // Use fetch with auth header to download
+    fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('Export failed');
+        return res.blob();
+      })
+      .then((blob) => {
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = `scan_results.${format}`;
+        a.click();
+        URL.revokeObjectURL(a.href);
+      })
+      .catch(() => toast.error('Failed to export scan results'));
+  };
+
+  if (loading && results.length === 0) {
+    return (
+      <div className="px-4 py-3 text-sm text-zinc-500">
+        Loading scan results...
+      </div>
+    );
+  }
+
+  if (results.length === 0) {
+    return (
+      <div className="px-4 py-3 text-sm text-zinc-500">
+        No scan results yet. Results will appear once a probe scans this
+        endpoint.
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-2 pb-3">
+      {/* Export buttons */}
+      <div className="flex items-center justify-between mb-3 px-2">
+        <span className="text-xs text-zinc-500">
+          {total} result{total !== 1 ? 's' : ''}
+        </span>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="ghost"
+            icon={<Download className="w-3 h-3" />}
+            onClick={() => handleExport('csv')}
+          >
+            CSV
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            icon={<Download className="w-3 h-3" />}
+            onClick={() => handleExport('json')}
+          >
+            JSON
+          </Button>
+        </div>
+      </div>
+
+      {/* Results table */}
+      <Table>
+        <TableHeader>
+          <TableHead>Scanned</TableHead>
+          <TableHead>Source</TableHead>
+          <TableHead>Region</TableHead>
+          <TableHead>TLS</TableHead>
+          <TableHead>Cert Subject</TableHead>
+          <TableHead>Expiry</TableHead>
+          <TableHead>Trusted</TableHead>
+          <TableHead>Latency</TableHead>
+        </TableHeader>
+        <tbody>
+          {results.map((r) => (
+            <TableRow key={r.id}>
+              <TableCell className="text-zinc-400 text-xs whitespace-nowrap">
+                {new Date(r.scannedAt).toLocaleString()}
+              </TableCell>
+              <TableCell>
+                <ProbeSourceBadge result={r} />
+              </TableCell>
+              <TableCell className="text-zinc-400 text-xs">
+                {r.probeRegion || '-'}
+              </TableCell>
+              <TableCell>
+                {r.connectionSuccess ? (
+                  <Badge variant="success" dot={false}>
+                    {r.tlsVersion || 'OK'}
+                  </Badge>
+                ) : (
+                  <Badge variant="danger">Failed</Badge>
+                )}
+              </TableCell>
+              <TableCell
+                className="text-zinc-300 text-xs max-w-[180px] truncate"
+                title={r.certSubject ?? undefined}
+              >
+                {r.certSubject || '-'}
+              </TableCell>
+              <TableCell>
+                <CertExpiryBadge days={r.certDaysUntilExpiry} />
+              </TableCell>
+              <TableCell>
+                {r.certTrusted == null ? (
+                  <span className="text-zinc-500">-</span>
+                ) : r.certTrusted ? (
+                  <span className="text-emerald-400">Yes</span>
+                ) : (
+                  <span className="text-red-400">No</span>
+                )}
+              </TableCell>
+              <TableCell className="text-zinc-400 text-xs">
+                {r.latencyMs != null ? `${r.latencyMs}ms` : '-'}
+              </TableCell>
+            </TableRow>
+          ))}
+        </tbody>
+      </Table>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-3 mt-3">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => fetchPage(page - 1)}
+            disabled={page <= 1 || loading}
+          >
+            Previous
+          </Button>
+          <span className="text-xs text-zinc-500">
+            Page {page} of {totalPages}
+          </span>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => fetchPage(page + 1)}
+            disabled={page >= totalPages || loading}
+          >
+            Next
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function EndpointManagement() {
   const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
   const [loading, setLoading] = useState(true);
   const [creating, setCreating] = useState(false);
   const deletingIds = useActionSet<string>();
   const togglingIds = useActionSet<string>();
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  // Latest results per endpoint (for the summary row)
+  const [latestResults, setLatestResults] = useState<
+    Record<string, ProbeScanResult[]>
+  >({});
 
   // Form state
   const [newHost, setNewHost] = useState('');
@@ -29,6 +255,20 @@ export default function EndpointManagement() {
       setLoading(true);
       const data = await endpointService.fetchEndpoints();
       setEndpoints(data);
+
+      // Fetch latest results for each endpoint
+      const latestMap: Record<string, ProbeScanResult[]> = {};
+      await Promise.all(
+        data.map(async (ep) => {
+          try {
+            const latest = await endpointService.fetchLatestResults(ep.id);
+            latestMap[ep.id] = latest;
+          } catch {
+            latestMap[ep.id] = [];
+          }
+        }),
+      );
+      setLatestResults(latestMap);
     } catch (error) {
       console.error('Failed to fetch endpoints:', error);
     } finally {
@@ -81,6 +321,7 @@ export default function EndpointManagement() {
       await endpointService.deleteEndpoint(ep.id);
       toast.success(`Endpoint ${ep.host}:${ep.port} deleted`);
       setEndpoints((prev) => prev.filter((e) => e.id !== ep.id));
+      if (expandedId === ep.id) setExpandedId(null);
     } catch (error) {
       console.error('Failed to delete endpoint:', error);
     } finally {
@@ -105,6 +346,45 @@ export default function EndpointManagement() {
     } finally {
       togglingIds.remove(ep.id);
     }
+  };
+
+  const toggleExpand = (id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  };
+
+  /** Derive a summary from the latest scan results for an endpoint */
+  const getSummary = (epId: string) => {
+    const results = latestResults[epId] ?? [];
+    if (results.length === 0) return null;
+
+    const hasHosted = results.some((r) => r.probeMode === 'hosted');
+    const hasConnected = results.some((r) => r.probeMode === 'connected');
+    const worstExpiry = results.reduce(
+      (min, r) =>
+        r.certDaysUntilExpiry != null &&
+        (min == null || r.certDaysUntilExpiry < min)
+          ? r.certDaysUntilExpiry
+          : min,
+      null as number | null,
+    );
+    const allTrusted = results.every((r) => r.certTrusted === true);
+    const anyFailed = results.some((r) => !r.connectionSuccess);
+    const latestScan = results.reduce(
+      (latest, r) =>
+        !latest || new Date(r.scannedAt) > new Date(latest)
+          ? r.scannedAt
+          : latest,
+      '' as string,
+    );
+
+    return {
+      hasHosted,
+      hasConnected,
+      worstExpiry,
+      allTrusted,
+      anyFailed,
+      latestScan,
+    };
   };
 
   if (loading) {
@@ -177,67 +457,128 @@ export default function EndpointManagement() {
         ) : (
           <Table>
             <TableHeader>
+              <TableHead className="w-8" />
               <TableHead>Host</TableHead>
               <TableHead>Port</TableHead>
               <TableHead>Label</TableHead>
               <TableHead>Status</TableHead>
-              <TableHead>Regions</TableHead>
-              <TableHead>Created</TableHead>
+              <TableHead>Probe Source</TableHead>
+              <TableHead>Cert Expiry</TableHead>
+              <TableHead>Last Scan</TableHead>
               <TableHead>Actions</TableHead>
             </TableHeader>
             <tbody>
-              {endpoints.map((ep) => (
-                <TableRow key={ep.id}>
-                  <TableCell className="font-medium text-zinc-200">
-                    {ep.host}
-                  </TableCell>
-                  <TableCell>{ep.port}</TableCell>
-                  <TableCell className="text-zinc-400">
-                    {ep.label || '-'}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={ep.isActive ? 'success' : 'danger'}>
-                      {ep.isActive ? 'Active' : 'Disabled'}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-zinc-400">
-                    {ep.hostedRegions && ep.hostedRegions.length > 0
-                      ? ep.hostedRegions.map((r) => r.region).join(', ')
-                      : '-'}
-                  </TableCell>
-                  <TableCell>
-                    {new Date(ep.createdAt).toLocaleDateString()}
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-1.5">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        icon={
-                          ep.isActive ? (
-                            <PowerOff className="w-3.5 h-3.5" />
-                          ) : (
-                            <Power className="w-3.5 h-3.5" />
-                          )
-                        }
-                        onClick={() => handleToggleActive(ep)}
-                        disabled={togglingIds.has(ep.id)}
-                      >
-                        {ep.isActive ? 'Disable' : 'Enable'}
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="danger"
-                        icon={<Trash2 className="w-3.5 h-3.5" />}
-                        onClick={() => handleDelete(ep)}
-                        disabled={deletingIds.has(ep.id)}
-                      >
-                        {deletingIds.has(ep.id) ? 'Deleting...' : 'Delete'}
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {endpoints.map((ep) => {
+                const summary = getSummary(ep.id);
+                const isExpanded = expandedId === ep.id;
+
+                return (
+                  <>
+                    <TableRow
+                      key={ep.id}
+                      className="cursor-pointer"
+                      onClick={() => toggleExpand(ep.id)}
+                    >
+                      <TableCell className="w-8 pr-0">
+                        {isExpanded ? (
+                          <ChevronDown className="w-4 h-4 text-zinc-500" />
+                        ) : (
+                          <ChevronRight className="w-4 h-4 text-zinc-500" />
+                        )}
+                      </TableCell>
+                      <TableCell className="font-medium text-zinc-200">
+                        {ep.host}
+                      </TableCell>
+                      <TableCell>{ep.port}</TableCell>
+                      <TableCell className="text-zinc-400">
+                        {ep.label || '-'}
+                      </TableCell>
+                      <TableCell>
+                        {summary?.anyFailed ? (
+                          <Badge variant="danger">Error</Badge>
+                        ) : (
+                          <Badge variant={ep.isActive ? 'success' : 'neutral'}>
+                            {ep.isActive ? 'Active' : 'Disabled'}
+                          </Badge>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-1.5">
+                          {summary?.hasHosted && (
+                            <Badge variant="info" dot={false}>
+                              <Cloud className="w-3 h-3 mr-0.5" />
+                              Managed
+                            </Badge>
+                          )}
+                          {summary?.hasConnected && (
+                            <Badge variant="neutral" dot={false}>
+                              <Server className="w-3 h-3 mr-0.5" />
+                              Connected
+                            </Badge>
+                          )}
+                          {!summary && (
+                            <span className="text-zinc-500 text-xs">
+                              No probes
+                            </span>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {summary ? (
+                          <CertExpiryBadge
+                            days={summary.worstExpiry ?? undefined}
+                          />
+                        ) : (
+                          <span className="text-zinc-500">-</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-zinc-400 text-xs whitespace-nowrap">
+                        {summary?.latestScan
+                          ? new Date(summary.latestScan).toLocaleString()
+                          : '-'}
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <div className="flex items-center gap-1.5">
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            icon={
+                              ep.isActive ? (
+                                <PowerOff className="w-3.5 h-3.5" />
+                              ) : (
+                                <Power className="w-3.5 h-3.5" />
+                              )
+                            }
+                            onClick={() => handleToggleActive(ep)}
+                            disabled={togglingIds.has(ep.id)}
+                          >
+                            {ep.isActive ? 'Disable' : 'Enable'}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="danger"
+                            icon={<Trash2 className="w-3.5 h-3.5" />}
+                            onClick={() => handleDelete(ep)}
+                            disabled={deletingIds.has(ep.id)}
+                          >
+                            {deletingIds.has(ep.id) ? '...' : 'Delete'}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                    {isExpanded && (
+                      <tr key={`${ep.id}-detail`}>
+                        <td
+                          colSpan={9}
+                          className="bg-zinc-900/50 border-b border-zinc-800/50"
+                        >
+                          <ScanResultsPanel endpointId={ep.id} />
+                        </td>
+                      </tr>
+                    )}
+                  </>
+                );
+              })}
             </tbody>
           </Table>
         )}

--- a/frontend/src/components/EndpointManagement.tsx
+++ b/frontend/src/components/EndpointManagement.tsx
@@ -1,0 +1,247 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Activity, Plus, Trash2, Power, PowerOff } from 'lucide-react';
+import { toast } from '../utils/toast';
+import type { Endpoint } from '@krakenkey/shared';
+import { useActionSet } from '../hooks/useActionSet';
+import * as endpointService from '../services/endpointService';
+import { Card } from './ui/Card';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+import { Badge } from './ui/Badge';
+import { Table, TableHeader, TableRow, TableHead, TableCell } from './ui/Table';
+import { PageHeader } from './ui/PageHeader';
+import { EmptyState } from './ui/EmptyState';
+
+export default function EndpointManagement() {
+  const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const deletingIds = useActionSet<string>();
+  const togglingIds = useActionSet<string>();
+
+  // Form state
+  const [newHost, setNewHost] = useState('');
+  const [newPort, setNewPort] = useState('443');
+  const [newLabel, setNewLabel] = useState('');
+
+  const fetchAll = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await endpointService.fetchEndpoints();
+      setEndpoints(data);
+    } catch (error) {
+      console.error('Failed to fetch endpoints:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const host = newHost.trim();
+    if (!host) {
+      toast.error('Please enter a hostname');
+      return;
+    }
+
+    try {
+      setCreating(true);
+      const endpoint = await endpointService.createEndpoint({
+        host,
+        port: parseInt(newPort, 10) || 443,
+        label: newLabel.trim() || undefined,
+      });
+      toast.success(`Endpoint ${endpoint.host}:${endpoint.port} added`);
+      setNewHost('');
+      setNewPort('443');
+      setNewLabel('');
+      setEndpoints((prev) => [endpoint, ...prev]);
+    } catch (error) {
+      console.error('Failed to create endpoint:', error);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (ep: Endpoint) => {
+    if (
+      !confirm(
+        `Delete endpoint ${ep.host}:${ep.port}? This will remove all associated scan results.`,
+      )
+    ) {
+      return;
+    }
+
+    try {
+      deletingIds.add(ep.id);
+      await endpointService.deleteEndpoint(ep.id);
+      toast.success(`Endpoint ${ep.host}:${ep.port} deleted`);
+      setEndpoints((prev) => prev.filter((e) => e.id !== ep.id));
+    } catch (error) {
+      console.error('Failed to delete endpoint:', error);
+    } finally {
+      deletingIds.remove(ep.id);
+    }
+  };
+
+  const handleToggleActive = async (ep: Endpoint) => {
+    try {
+      togglingIds.add(ep.id);
+      const updated = await endpointService.updateEndpoint(ep.id, {
+        isActive: !ep.isActive,
+      });
+      setEndpoints((prev) =>
+        prev.map((e) => (e.id === updated.id ? updated : e)),
+      );
+      toast.success(
+        `Endpoint ${ep.host} ${updated.isActive ? 'enabled' : 'disabled'}`,
+      );
+    } catch (error) {
+      console.error('Failed to toggle endpoint:', error);
+    } finally {
+      togglingIds.remove(ep.id);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div>
+        <PageHeader title="Endpoints" icon={<Activity className="w-6 h-6" />} />
+        <p className="text-zinc-400">Loading endpoints...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title="Endpoints"
+        description="Monitor TLS certificates on your endpoints. Connected and hosted probes scan these automatically."
+        icon={<Activity className="w-6 h-6" />}
+      />
+
+      {/* Create Endpoint Form */}
+      <Card className="mb-6">
+        <h3 className="text-sm font-medium text-zinc-400 mb-4">Add Endpoint</h3>
+        <form onSubmit={handleCreate}>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <Input
+              placeholder="Hostname (e.g., example.com)"
+              value={newHost}
+              onChange={(e) => setNewHost(e.target.value)}
+              disabled={creating}
+              className="flex-1"
+            />
+            <Input
+              placeholder="Port"
+              value={newPort}
+              onChange={(e) => setNewPort(e.target.value)}
+              disabled={creating}
+              className="w-24"
+            />
+            <Input
+              placeholder="Label (optional)"
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              disabled={creating}
+              className="flex-1"
+            />
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={creating}
+              icon={<Plus className="w-3.5 h-3.5" />}
+            >
+              {creating ? 'Adding...' : 'Add'}
+            </Button>
+          </div>
+        </form>
+      </Card>
+
+      {/* Endpoints List */}
+      <Card>
+        <h3 className="text-sm font-medium text-zinc-400 mb-4">
+          Monitored Endpoints ({endpoints.length})
+        </h3>
+
+        {endpoints.length === 0 ? (
+          <EmptyState
+            icon={<Activity className="w-8 h-8" />}
+            title="No endpoints yet"
+            description="Add an endpoint above to start monitoring its TLS certificate."
+          />
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableHead>Host</TableHead>
+              <TableHead>Port</TableHead>
+              <TableHead>Label</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead>Regions</TableHead>
+              <TableHead>Created</TableHead>
+              <TableHead>Actions</TableHead>
+            </TableHeader>
+            <tbody>
+              {endpoints.map((ep) => (
+                <TableRow key={ep.id}>
+                  <TableCell className="font-medium text-zinc-200">
+                    {ep.host}
+                  </TableCell>
+                  <TableCell>{ep.port}</TableCell>
+                  <TableCell className="text-zinc-400">
+                    {ep.label || '-'}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={ep.isActive ? 'success' : 'danger'}>
+                      {ep.isActive ? 'Active' : 'Disabled'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-zinc-400">
+                    {ep.hostedRegions && ep.hostedRegions.length > 0
+                      ? ep.hostedRegions.map((r) => r.region).join(', ')
+                      : '-'}
+                  </TableCell>
+                  <TableCell>
+                    {new Date(ep.createdAt).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1.5">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        icon={
+                          ep.isActive ? (
+                            <PowerOff className="w-3.5 h-3.5" />
+                          ) : (
+                            <Power className="w-3.5 h-3.5" />
+                          )
+                        }
+                        onClick={() => handleToggleActive(ep)}
+                        disabled={togglingIds.has(ep.id)}
+                      >
+                        {ep.isActive ? 'Disable' : 'Enable'}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        icon={<Trash2 className="w-3.5 h-3.5" />}
+                        onClick={() => handleDelete(ep)}
+                        disabled={deletingIds.has(ep.id)}
+                      >
+                        {deletingIds.has(ep.id) ? 'Deleting...' : 'Delete'}
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </tbody>
+          </Table>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/EndpointManagement.tsx
+++ b/frontend/src/components/EndpointManagement.tsx
@@ -243,6 +243,9 @@ export default function EndpointManagement() {
   const scanningIds = useActionSet<string>();
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const scanRequestedRef = useRef<{ endpointId: string; at: Date } | null>(
+    null,
+  );
 
   // Latest results per endpoint (for the summary row)
   const [latestResults, setLatestResults] = useState<
@@ -370,19 +373,43 @@ export default function EndpointManagement() {
     }
   };
 
-  const startAutoRefresh = useCallback(() => {
-    if (refreshTimerRef.current) return;
-    let ticks = 0;
-    refreshTimerRef.current = setInterval(() => {
-      ticks++;
-      fetchAll();
-      if (ticks >= 6) {
-        // Stop after ~60s (6 x 10s)
-        if (refreshTimerRef.current) clearInterval(refreshTimerRef.current);
-        refreshTimerRef.current = null;
-      }
-    }, 10_000);
-  }, [fetchAll]);
+  const stopAutoRefresh = useCallback(() => {
+    if (refreshTimerRef.current) {
+      clearInterval(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+    scanRequestedRef.current = null;
+  }, []);
+
+  const startAutoRefresh = useCallback(
+    (endpointId: string) => {
+      if (refreshTimerRef.current) return;
+      const requestedAt = new Date();
+      scanRequestedRef.current = { endpointId, at: requestedAt };
+      let ticks = 0;
+      refreshTimerRef.current = setInterval(() => {
+        ticks++;
+        fetchAll();
+        if (ticks >= 6) {
+          stopAutoRefresh();
+        }
+      }, 10_000);
+    },
+    [fetchAll, stopAutoRefresh],
+  );
+
+  // Stop polling once fresh results arrive for the scanned endpoint
+  useEffect(() => {
+    const req = scanRequestedRef.current;
+    if (!req || !refreshTimerRef.current) return;
+    const results = latestResults[req.endpointId] ?? [];
+    const hasFreshResult = results.some(
+      (r) => r.scannedAt && new Date(r.scannedAt) > req.at,
+    );
+    if (hasFreshResult) {
+      stopAutoRefresh();
+    }
+  }, [latestResults, stopAutoRefresh]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -396,7 +423,7 @@ export default function EndpointManagement() {
       scanningIds.add(ep.id);
       await endpointService.requestScan(ep.id);
       toast.success(`Scan requested for ${ep.host}:${ep.port}`);
-      startAutoRefresh();
+      startAutoRefresh(ep.id);
     } catch (error) {
       console.error('Failed to request scan:', error);
     } finally {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Menu,
   X,
   Building2,
+  Activity,
 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { PlanBadge } from './ui/PlanBadge';
@@ -19,6 +20,7 @@ const navItems = [
   { to: '/dashboard', icon: LayoutDashboard, label: 'Overview', end: true },
   { to: '/dashboard/domains', icon: Globe, label: 'Domains' },
   { to: '/dashboard/certificates', icon: Shield, label: 'Certificates' },
+  { to: '/dashboard/endpoints', icon: Activity, label: 'Endpoints' },
   { to: '/dashboard/api-keys', icon: Key, label: 'API Keys' },
   { to: '/dashboard/organizations', icon: Building2, label: 'Organization' },
   { to: '/dashboard/billing', icon: CreditCard, label: 'Billing' },

--- a/frontend/src/services/endpointService.ts
+++ b/frontend/src/services/endpointService.ts
@@ -1,0 +1,82 @@
+import api from './api';
+import { API_ROUTES } from '@krakenkey/shared';
+import type {
+  Endpoint,
+  EndpointHostedRegion,
+  CreateEndpointRequest,
+  UpdateEndpointRequest,
+  AddHostedRegionRequest,
+  ProbeScanResult,
+} from '@krakenkey/shared';
+
+export async function fetchEndpoints(): Promise<Endpoint[]> {
+  const response = await api.get<Endpoint[]>(API_ROUTES.ENDPOINTS.BASE);
+  return response.data;
+}
+
+export async function fetchEndpoint(id: string): Promise<Endpoint> {
+  const response = await api.get<Endpoint>(API_ROUTES.ENDPOINTS.BY_ID(id));
+  return response.data;
+}
+
+export async function createEndpoint(
+  req: CreateEndpointRequest,
+): Promise<Endpoint> {
+  const response = await api.post<Endpoint>(API_ROUTES.ENDPOINTS.BASE, req);
+  return response.data;
+}
+
+export async function updateEndpoint(
+  id: string,
+  req: UpdateEndpointRequest,
+): Promise<Endpoint> {
+  const response = await api.patch<Endpoint>(
+    API_ROUTES.ENDPOINTS.BY_ID(id),
+    req,
+  );
+  return response.data;
+}
+
+export async function deleteEndpoint(id: string): Promise<void> {
+  await api.delete(API_ROUTES.ENDPOINTS.BY_ID(id));
+}
+
+export async function addHostedRegion(
+  id: string,
+  region: string,
+): Promise<EndpointHostedRegion> {
+  const payload: AddHostedRegionRequest = { region };
+  const response = await api.post<EndpointHostedRegion>(
+    API_ROUTES.ENDPOINTS.REGIONS(id),
+    payload,
+  );
+  return response.data;
+}
+
+export async function removeHostedRegion(
+  id: string,
+  region: string,
+): Promise<void> {
+  await api.delete(API_ROUTES.ENDPOINTS.REGION(id, region));
+}
+
+export async function fetchResults(
+  id: string,
+  page = 1,
+  limit = 20,
+): Promise<{ data: ProbeScanResult[]; total: number }> {
+  const response = await api.get<{ data: ProbeScanResult[]; total: number }>(
+    API_ROUTES.ENDPOINTS.RESULTS(id),
+    { params: { page, limit } },
+  );
+  return response.data;
+}
+
+export async function fetchLatestResults(
+  id: string,
+): Promise<ProbeScanResult[]> {
+  const response = await api.get<ProbeScanResult[]>(
+    API_ROUTES.ENDPOINTS.LATEST_RESULTS(id),
+  );
+  return response.data;
+}

--- a/frontend/src/services/endpointService.ts
+++ b/frontend/src/services/endpointService.ts
@@ -72,6 +72,10 @@ export async function fetchResults(
   return response.data;
 }
 
+export function getExportUrl(id: string, format: 'json' | 'csv'): string {
+  return `${api.defaults.baseURL}${API_ROUTES.ENDPOINTS.EXPORT_RESULTS(id)}?format=${format}`;
+}
+
 export async function fetchLatestResults(
   id: string,
 ): Promise<ProbeScanResult[]> {

--- a/frontend/src/services/endpointService.ts
+++ b/frontend/src/services/endpointService.ts
@@ -3,6 +3,7 @@ import { API_ROUTES } from '@krakenkey/shared';
 import type {
   Endpoint,
   EndpointHostedRegion,
+  EndpointProbeAssignment,
   CreateEndpointRequest,
   UpdateEndpointRequest,
   AddHostedRegionRequest,
@@ -72,8 +73,48 @@ export async function fetchResults(
   return response.data;
 }
 
+export async function requestScan(id: string): Promise<Endpoint> {
+  const response = await api.post<Endpoint>(API_ROUTES.ENDPOINTS.SCAN(id));
+  return response.data;
+}
+
 export function getExportUrl(id: string, format: 'json' | 'csv'): string {
   return `${api.defaults.baseURL}${API_ROUTES.ENDPOINTS.EXPORT_RESULTS(id)}?format=${format}`;
+}
+
+/** Probe with basic metadata for the assignment picker */
+export interface ProbeOption {
+  id: string;
+  name: string;
+  mode: string;
+  region?: string;
+  status: string;
+  lastSeenAt?: string;
+}
+
+export async function fetchUserProbes(): Promise<ProbeOption[]> {
+  const response = await api.get<ProbeOption[]>(
+    API_ROUTES.ENDPOINTS.PROBES_MINE,
+  );
+  return response.data;
+}
+
+export async function assignProbes(
+  endpointId: string,
+  probeIds: string[],
+): Promise<EndpointProbeAssignment[]> {
+  const response = await api.post<EndpointProbeAssignment[]>(
+    API_ROUTES.ENDPOINTS.PROBES(endpointId),
+    { probeIds },
+  );
+  return response.data;
+}
+
+export async function unassignProbe(
+  endpointId: string,
+  probeId: string,
+): Promise<void> {
+  await api.delete(API_ROUTES.ENDPOINTS.PROBE(endpointId, probeId));
 }
 
 export async function fetchLatestResults(

--- a/shared/src/constants/routes.ts
+++ b/shared/src/constants/routes.ts
@@ -29,6 +29,15 @@ export const API_ROUTES = {
     BASE: '/auth/api-keys',
     BY_ID: (id: string) => `/auth/api-keys/${id}`,
   },
+  ENDPOINTS: {
+    BASE: '/endpoints',
+    BY_ID: (id: string) => `/endpoints/${id}`,
+    REGIONS: (id: string) => `/endpoints/${id}/regions`,
+    REGION: (id: string, region: string) =>
+      `/endpoints/${id}/regions/${region}`,
+    RESULTS: (id: string) => `/endpoints/${id}/results`,
+    LATEST_RESULTS: (id: string) => `/endpoints/${id}/results/latest`,
+  },
   BILLING: {
     CHECKOUT: '/billing/checkout',
     SUBSCRIPTION: '/billing/subscription',

--- a/shared/src/constants/routes.ts
+++ b/shared/src/constants/routes.ts
@@ -36,6 +36,11 @@ export const API_ROUTES = {
     REGION: (id: string, region: string) =>
       `/endpoints/${id}/regions/${region}`,
     RESULTS: (id: string) => `/endpoints/${id}/results`,
+    PROBES_MINE: '/endpoints/probes/mine',
+    PROBES: (id: string) => `/endpoints/${id}/probes`,
+    PROBE: (id: string, probeId: string) =>
+      `/endpoints/${id}/probes/${probeId}`,
+    SCAN: (id: string) => `/endpoints/${id}/scan`,
     EXPORT_RESULTS: (id: string) => `/endpoints/${id}/results/export`,
     LATEST_RESULTS: (id: string) => `/endpoints/${id}/results/latest`,
   },

--- a/shared/src/constants/routes.ts
+++ b/shared/src/constants/routes.ts
@@ -36,6 +36,7 @@ export const API_ROUTES = {
     REGION: (id: string, region: string) =>
       `/endpoints/${id}/regions/${region}`,
     RESULTS: (id: string) => `/endpoints/${id}/results`,
+    EXPORT_RESULTS: (id: string) => `/endpoints/${id}/results/export`,
     LATEST_RESULTS: (id: string) => `/endpoints/${id}/results/latest`,
   },
   BILLING: {

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -6,4 +6,5 @@ export * from './types/api-key';
 export * from './types/api-error';
 export * from './types/auth';
 export * from './types/subscription';
+export * from './types/endpoint';
 export * from './constants/routes';

--- a/shared/src/types/endpoint.ts
+++ b/shared/src/types/endpoint.ts
@@ -8,7 +8,9 @@ export interface Endpoint {
   sni?: string;
   label?: string;
   isActive: boolean;
+  lastScanRequestedAt?: string;
   hostedRegions?: EndpointHostedRegion[];
+  probeAssignments?: EndpointProbeAssignment[];
   createdAt: string;
   updatedAt: string;
 }
@@ -20,11 +22,28 @@ export interface EndpointHostedRegion {
   createdAt: string;
 }
 
+export interface EndpointProbeAssignment {
+  id: string;
+  endpointId: string;
+  probeId: string;
+  probe?: {
+    id: string;
+    name: string;
+    mode: string;
+    region?: string;
+    status: string;
+    lastSeenAt?: string;
+  };
+  createdAt: string;
+}
+
 export interface CreateEndpointRequest {
   host: string;
   port?: number;
   sni?: string;
   label?: string;
+  probeIds?: string[];
+  hostedRegions?: string[];
 }
 
 export interface UpdateEndpointRequest {

--- a/shared/src/types/endpoint.ts
+++ b/shared/src/types/endpoint.ts
@@ -1,0 +1,72 @@
+export type ProbeMode = 'standalone' | 'connected' | 'hosted';
+
+export interface Endpoint {
+  id: string;
+  userId: string;
+  host: string;
+  port: number;
+  sni?: string;
+  label?: string;
+  isActive: boolean;
+  hostedRegions?: EndpointHostedRegion[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EndpointHostedRegion {
+  id: string;
+  endpointId: string;
+  region: string;
+  createdAt: string;
+}
+
+export interface CreateEndpointRequest {
+  host: string;
+  port?: number;
+  sni?: string;
+  label?: string;
+}
+
+export interface UpdateEndpointRequest {
+  sni?: string;
+  label?: string;
+  isActive?: boolean;
+}
+
+export interface AddHostedRegionRequest {
+  region: string;
+}
+
+export interface ProbeScanResult {
+  id: string;
+  probeId: string;
+  endpointId?: string;
+  host: string;
+  port: number;
+  sni?: string;
+  userId?: string;
+  probeMode?: ProbeMode;
+  probeRegion?: string;
+  connectionSuccess: boolean;
+  connectionError?: string;
+  latencyMs?: number;
+  tlsVersion?: string;
+  cipherSuite?: string;
+  ocspStapled?: boolean;
+  certSubject?: string;
+  certSans?: string[];
+  certIssuer?: string;
+  certSerialNumber?: string;
+  certNotBefore?: string;
+  certNotAfter?: string;
+  certDaysUntilExpiry?: number;
+  certKeyType?: string;
+  certKeySize?: number;
+  certSignatureAlgorithm?: string;
+  certFingerprint?: string;
+  certChainDepth?: number;
+  certChainComplete?: boolean;
+  certTrusted?: boolean;
+  scannedAt: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

Adds hosted probe infrastructure with full endpoint monitoring support. This introduces the ability to run probes in three modes — standalone, connected, and hosted — enabling centralized endpoint health monitoring with configurable probe assignments per region.

### Backend
- **Hosted probe service**: New probe registration, scan report submission, and service-to-service auth via service API keys
- **Endpoint management**: Full CRUD for monitored endpoints with hosted region configuration and per-endpoint probe assignments
- **Probe modes**: Support for standalone (self-contained), connected (user-managed reporting to platform), and hosted (platform-managed) probe operation
- **Scan data pipeline**: Probe scan results stored, exposed via API, with automatic cleanup of stale data
- **Monitoring service**: Background probe health monitoring with configurable intervals
- **Billing integration**: Plan-based limits for endpoint and probe usage
- **Migrations**: Three new migrations for probes/service keys, endpoints/probe enhancements, and endpoint-probe assignments

### Frontend
- **Endpoint management UI**: New `EndpointManagement` component with endpoint CRUD, probe assignment configuration, and scan result visualization
- **Auto-refresh**: Polling-based live monitoring dashboard with configurable refresh behavior
- **Endpoint service**: API client layer for all endpoint and probe assignment operations

### Shared
- Endpoint types, enums, and route constants

## Test plan
- [ ] Verify probe registration and scan report submission with service API keys
- [ ] Test endpoint CRUD operations (create, read, update, delete)
- [ ] Confirm probe assignment to endpoints works across hosted regions
- [ ] Validate scan results are displayed and auto-refreshed in the frontend
- [ ] Check plan-based limits are enforced for endpoints and probes
- [ ] Run existing unit tests (`endpoints.service.spec.ts`, `endpoints.controller.spec.ts`, `probes.service.spec.ts`, `probe-monitor.service.spec.ts`, `scan-result-cleanup.service.spec.ts`)
- [ ] Verify DB migrations apply and roll back cleanly
