### PR TITLE
feat: security hardening

### DIFF
--- a/.github/workflows/backend-docker-publish.yml
+++ b/.github/workflows/backend-docker-publish.yml
@@ -15,6 +15,9 @@ on:
       - .github/workflows/backend-docker-publish.yml
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/backend

--- a/.github/workflows/frontend-docker-publish.yml
+++ b/.github/workflows/frontend-docker-publish.yml
@@ -15,6 +15,9 @@ on:
       - .github/workflows/frontend-docker-publish.yml
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}/frontend

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -8,6 +8,9 @@ on:
       - 'shared/**'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
   group: sync-openapi
   cancel-in-progress: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,9 @@ on:
       - 'frontend/**'
       - 'shared/**'
 
+permissions:
+  contents: read
+
 jobs:
   backend-unit:
     name: Backend unit tests

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { createHash } from 'crypto';
+import { createHmac } from 'crypto';
 import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UserApiKey } from './entities/user-api-key.entity';
@@ -11,12 +11,15 @@ import { Domain } from '../domains/entities/domain.entity';
 import { TlsCrt } from '../certs/tls/entities/tls-crt.entity';
 import { BillingService } from '../billing/billing.service';
 
+const HMAC_SECRET = 'test-hmac-secret';
+
 const CONFIG: Record<string, string> = {
   KK_AUTHENTIK_DOMAIN: 'auth.example.com',
   KK_AUTHENTIK_ENROLLMENT_SLUG: 'krakenkey-enrollment',
   KK_AUTHENTIK_CLIENT_ID: 'krakenkey-backend',
   KK_AUTHENTIK_CLIENT_SECRET: 's3cr3t',
   KK_AUTHENTIK_REDIRECT_URI: 'https://api.example.com/auth/callback',
+  KK_HMAC_SECRET: HMAC_SECRET,
 };
 
 /** Build a fake JWT with a real base64 payload so handleCallback can decode it. */
@@ -320,7 +323,7 @@ describe('AuthService', () => {
       expect(result.apiKey).toMatch(/^kk_/);
     });
 
-    it('stores the SHA-256 hash, not the raw key', async () => {
+    it('stores the HMAC-SHA256 hash, not the raw key', async () => {
       let capturedHash = '';
       mockUserApiKeyRepo.create.mockImplementation(
         ({ hash }: { hash: string }) => {
@@ -331,7 +334,7 @@ describe('AuthService', () => {
       mockUserApiKeyRepo.save.mockResolvedValue({});
 
       const result = await service.createApiKey('user-1', 'k');
-      const expectedHash = createHash('sha256')
+      const expectedHash = createHmac('sha256', HMAC_SECRET)
         .update(result.apiKey)
         .digest('hex');
       expect(capturedHash).toBe(expectedHash);
@@ -361,13 +364,15 @@ describe('AuthService', () => {
   // validateApiKey
   // ---------------------------------------------------------------------------
   describe('validateApiKey', () => {
-    it('looks up the SHA-256 hash of the raw key', async () => {
+    it('looks up the HMAC-SHA256 hash of the raw key', async () => {
       mockUserApiKeyRepo.findOne.mockResolvedValue(null);
       const rawKey = 'kk_test_raw_key';
 
       await service.validateApiKey(rawKey);
 
-      const expectedHash = createHash('sha256').update(rawKey).digest('hex');
+      const expectedHash = createHmac('sha256', HMAC_SECRET)
+        .update(rawKey)
+        .digest('hex');
       expect(mockUserApiKeyRepo.findOne).toHaveBeenCalledWith({
         where: { hash: expectedHash },
         relations: ['user'],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -11,7 +11,7 @@ import { In, Repository } from 'typeorm';
 import { UserApiKey } from './entities/user-api-key.entity';
 import { ServiceApiKey } from './entities/service-api-key.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { createHash, randomBytes } from 'crypto';
+import { createHmac, randomBytes } from 'crypto';
 import { User } from '../users/entities/user.entity';
 import { Domain } from '../domains/entities/domain.entity';
 import { TlsCrt } from '../certs/tls/entities/tls-crt.entity';
@@ -50,6 +50,18 @@ export class AuthService implements OnModuleInit {
   }
 
   /**
+   * HMAC-SHA256 key hashing with a server-side secret.
+   * Prevents offline key verification if the DB is compromised without the secret.
+   */
+  private hashKey(raw: string): string {
+    const secret = this.config.get<string>('KK_HMAC_SECRET');
+    if (!secret) {
+      throw new Error('KK_HMAC_SECRET must be set');
+    }
+    return createHmac('sha256', secret).update(raw).digest('hex');
+  }
+
+  /**
    * Seeds a service key from KK_PROBE_API_KEY env var on startup.
    * Idempotent: skips if the hash already exists.
    */
@@ -57,7 +69,7 @@ export class AuthService implements OnModuleInit {
     const rawKey = this.config.get<string>('KK_PROBE_API_KEY');
     if (!rawKey) return;
 
-    const hash = createHash('sha256').update(rawKey).digest('hex');
+    const hash = this.hashKey(rawKey);
     const existing = await this.serviceApiKeyRepo.findOne({ where: { hash } });
     if (existing) return;
 
@@ -242,7 +254,7 @@ export class AuthService implements OnModuleInit {
     }
 
     const rawKey = `kk_${randomBytes(24).toString('hex')}`;
-    const hash = createHash('sha256').update(rawKey).digest('hex');
+    const hash = this.hashKey(rawKey);
 
     const apiKey = this.userApiKeyRepo.create({
       name,
@@ -294,7 +306,7 @@ export class AuthService implements OnModuleInit {
    * Returns the UserApiKey record with user relation if valid, null otherwise.
    */
   async validateApiKey(rawKey: string) {
-    const hash = createHash('sha256').update(rawKey).digest('hex');
+    const hash = this.hashKey(rawKey);
     const record = await this.userApiKeyRepo.findOne({
       where: { hash },
       relations: ['user'],
@@ -401,7 +413,7 @@ export class AuthService implements OnModuleInit {
   // --- Service API Key Management ---
 
   async validateServiceKey(rawKey: string): Promise<ServiceApiKey | null> {
-    const hash = createHash('sha256').update(rawKey).digest('hex');
+    const hash = this.hashKey(rawKey);
     const record = await this.serviceApiKeyRepo.findOne({ where: { hash } });
     if (!record) return null;
     if (record.revokedAt) return null;
@@ -414,7 +426,7 @@ export class AuthService implements OnModuleInit {
     expiresAt?: string,
   ): Promise<{ apiKey: string; id: string; name: string }> {
     const rawKey = `kk_svc_${randomBytes(24).toString('hex')}`;
-    const hash = createHash('sha256').update(rawKey).digest('hex');
+    const hash = this.hashKey(rawKey);
 
     const key = this.serviceApiKeyRepo.create({
       name,

--- a/backend/src/certs/tls/util/csr-util.service.ts
+++ b/backend/src/certs/tls/util/csr-util.service.ts
@@ -132,15 +132,16 @@ export class CsrUtilService {
     const header = '-----BEGIN CERTIFICATE REQUEST-----';
     const footer = '-----END CERTIFICATE REQUEST-----';
 
-    const match = trimmed.match(
-      /-----BEGIN CERTIFICATE REQUEST-----([\s\S]+?)-----END CERTIFICATE REQUEST-----/,
-    );
-    if (!match) {
+    const beginIdx = trimmed.indexOf(header);
+    const endIdx = trimmed.indexOf(footer);
+    if (beginIdx === -1 || endIdx <= beginIdx) {
       throw new BadRequestException('CSR must include PEM header and footer');
     }
 
     // Strip all whitespace from base64 body and re-wrap at 64 chars per line
-    const base64 = match[1].replace(/\s/g, '');
+    const base64 = trimmed
+      .slice(beginIdx + header.length, endIdx)
+      .replace(/\s/g, '');
     const chunks = base64.match(/.{1,64}/g) || [];
     return `${header}\n${chunks.join('\n')}\n${footer}`;
   }


### PR DESCRIPTION
This pull request introduces several important security and infrastructure improvements. The main focus is on enhancing API key security in the backend by switching from plain SHA-256 hashing to HMAC-SHA256 with a server-side secret. Additionally, the pull request standardizes permissions in GitHub Actions workflows and improves the robustness of PEM parsing.

**Backend API Key Security Improvements:**

- Switched from using `createHash('sha256')` to `createHmac('sha256', secret)` for hashing API keys in `AuthService`, ensuring that if the database is compromised, attackers cannot verify keys without the server-side secret (`KK_HMAC_SECRET`). This affects all code paths that create or validate user and service API keys. [[1]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398L14-R14) [[2]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398R52-R63) [[3]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398L60-R72) [[4]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398L245-R257) [[5]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398L297-R309) [[6]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398L404-R416) [[7]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398L417-R429)
- Updated tests in `auth.service.spec.ts` to use HMAC-SHA256 with the test secret, ensuring that the new hashing logic is properly verified. [[1]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L4-R4) [[2]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074R14-R22) [[3]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L323-R326) [[4]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L334-R337) [[5]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L364-R375)

**CI/CD Workflow Enhancements:**

- Added explicit `permissions: contents: read` to all GitHub Actions workflows (`backend-docker-publish.yml`, `frontend-docker-publish.yml`, `sync-openapi-spec.yml`, `test.yaml`) to follow the principle of least privilege and improve security posture. [[1]](diffhunk://#diff-22c808a5c5c6ab9eafb0e01f900ed3236b421acb2e0e91e0d23678dea7396d17R18-R20) [[2]](diffhunk://#diff-44b226db8fde19d012282f0a98900c5bd73cdb784dfe5bfd71b29a73d20bb1cbR18-R20) [[3]](diffhunk://#diff-2c0f0b5f3540f592b211e36778e1b6dd0cd6c6365f332a9a7021210a61b2be3bR11-R13) [[4]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692R17-R19)

**Certificate Request Parsing Robustness:**

- Improved PEM parsing in `CsrUtilService` by switching from regex matching to explicit header/footer index checks, making the parsing of certificate signing requests more robust and less error-prone.