### PR TITLE
feat: implement scrypt

### DIFF
--- a/.github/workflows/backend-docker-publish.yml
+++ b/.github/workflows/backend-docker-publish.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/frontend-docker-publish.yml
+++ b/.github/workflows/frontend-docker-publish.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -61,3 +61,7 @@ KK_AUTHENTIK_CLIENT_ID=krakenkey-backend
 KK_AUTHENTIK_CLIENT_SECRET=your_authentik_client_secret_here
 KK_AUTHENTIK_REDIRECT_URI=https://api-dev.krakenkey.io/auth/callback
 KK_AUTHENTIK_POST_ENROLLMENT_REDIRECT=https://api-dev.krakenkey.io/auth/login
+
+## HMAC Secret (API key hashing) ##
+# Generate with: openssl rand -hex 32
+KK_HMAC_SECRET=your_hmac_secret_here

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { createHmac } from 'crypto';
+import { scryptSync } from 'crypto';
 import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { UserApiKey } from './entities/user-api-key.entity';
@@ -323,7 +323,7 @@ describe('AuthService', () => {
       expect(result.apiKey).toMatch(/^kk_/);
     });
 
-    it('stores the HMAC-SHA256 hash, not the raw key', async () => {
+    it('stores the scrypt hash, not the raw key', async () => {
       let capturedHash = '';
       mockUserApiKeyRepo.create.mockImplementation(
         ({ hash }: { hash: string }) => {
@@ -334,9 +334,9 @@ describe('AuthService', () => {
       mockUserApiKeyRepo.save.mockResolvedValue({});
 
       const result = await service.createApiKey('user-1', 'k');
-      const expectedHash = createHmac('sha256', HMAC_SECRET)
-        .update(result.apiKey)
-        .digest('hex');
+      const expectedHash = scryptSync(result.apiKey, HMAC_SECRET, 64).toString(
+        'hex',
+      );
       expect(capturedHash).toBe(expectedHash);
     });
 
@@ -364,15 +364,13 @@ describe('AuthService', () => {
   // validateApiKey
   // ---------------------------------------------------------------------------
   describe('validateApiKey', () => {
-    it('looks up the HMAC-SHA256 hash of the raw key', async () => {
+    it('looks up the scrypt hash of the raw key', async () => {
       mockUserApiKeyRepo.findOne.mockResolvedValue(null);
       const rawKey = 'kk_test_raw_key';
 
       await service.validateApiKey(rawKey);
 
-      const expectedHash = createHmac('sha256', HMAC_SECRET)
-        .update(rawKey)
-        .digest('hex');
+      const expectedHash = scryptSync(rawKey, HMAC_SECRET, 64).toString('hex');
       expect(mockUserApiKeyRepo.findOne).toHaveBeenCalledWith({
         where: { hash: expectedHash },
         relations: ['user'],

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -11,7 +11,7 @@ import { In, Repository } from 'typeorm';
 import { UserApiKey } from './entities/user-api-key.entity';
 import { ServiceApiKey } from './entities/service-api-key.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { createHmac, randomBytes } from 'crypto';
+import { scryptSync, randomBytes } from 'crypto';
 import { User } from '../users/entities/user.entity';
 import { Domain } from '../domains/entities/domain.entity';
 import { TlsCrt } from '../certs/tls/entities/tls-crt.entity';
@@ -46,19 +46,28 @@ export class AuthService implements OnModuleInit {
   ) {}
 
   async onModuleInit() {
+    const secret = this.config.get<string>('KK_HMAC_SECRET');
+    if (!secret) {
+      this.logger.error(
+        'KK_HMAC_SECRET is not set — API key creation and validation will fail. ' +
+          'Add the secret to your environment before using key-based auth.',
+      );
+    }
     await this.seedServiceKey();
   }
 
   /**
-   * HMAC-SHA256 key hashing with a server-side secret.
+   * scrypt key hashing with a server-side secret as salt.
    * Prevents offline key verification if the DB is compromised without the secret.
    */
   private hashKey(raw: string): string {
     const secret = this.config.get<string>('KK_HMAC_SECRET');
     if (!secret) {
-      throw new Error('KK_HMAC_SECRET must be set');
+      throw new Error(
+        'KK_HMAC_SECRET must be set to use key-based authentication',
+      );
     }
-    return createHmac('sha256', secret).update(raw).digest('hex');
+    return scryptSync(raw, secret, 64).toString('hex');
   }
 
   /**
@@ -68,6 +77,12 @@ export class AuthService implements OnModuleInit {
   private async seedServiceKey() {
     const rawKey = this.config.get<string>('KK_PROBE_API_KEY');
     if (!rawKey) return;
+
+    const secret = this.config.get<string>('KK_HMAC_SECRET');
+    if (!secret) {
+      this.logger.warn('Skipping service key seed — KK_HMAC_SECRET is not set');
+      return;
+    }
 
     const hash = this.hashKey(rawKey);
     const existing = await this.serviceApiKeyRepo.findOne({ where: { hash } });


### PR DESCRIPTION
This pull request updates the API key hashing mechanism in the authentication service from HMAC-SHA256 to scrypt, enhancing security by making hashes more resistant to brute-force attacks. It also updates related environment variables, error handling, and test cases to reflect this change.

**Security improvements (API key hashing):**
* Switched the API key hashing algorithm from HMAC-SHA256 to scrypt for stronger, more secure key derivation in `AuthService` (`auth.service.ts`), including updating the `hashKey` method and related documentation/comments.
* Updated all references and tests to use scrypt instead of HMAC-SHA256, ensuring both key creation and validation use the new algorithm (`auth.service.spec.ts`). [[1]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L4-R4) [[2]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L326-R326) [[3]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L337-R339) [[4]](diffhunk://#diff-022d93b958fa1f237ed014c5d8f0302360ab15a09a94768576ed16a975d4c074L367-R373)

**Configuration and error handling:**
* Added `KK_HMAC_SECRET` to `.env.example` with instructions for generating a secure secret, and improved error/warning messages if the secret is missing during initialization or service key seeding (`.env.example`, `auth.service.ts`). [[1]](diffhunk://#diff-361f2d0f55c49b270125820efb10f0d9433ced883e9d59b1f58c27b877dc2080R64-R67) [[2]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398R49-R70) [[3]](diffhunk://#diff-34c4ae148a4bf99d6ec2000c464097cd50c195fbb68082b4e13dab69ea96b398R81-R86)

These changes collectively improve the security and reliability of API key management in the authentication service.