### PR TITLE
Chore/update limits

### DIFF
--- a/backend/docs/BILLING.md
+++ b/backend/docs/BILLING.md
@@ -12,8 +12,8 @@ KrakenKey uses Stripe for subscription management with five plan tiers that cont
 | **Certificates / month** | 5 | 50 | 250 | 1,000 | Unlimited |
 | **Active Certificates** | 10 | 75 | 375 | 1,500 | Unlimited |
 | **Scan Interval** | 60 min | 30 min | 5 min | 1 min | Custom |
-| **Hosted Probe Regions** | — | — | 5 | 15 | Unlimited |
-| **Hosted Endpoints** | — | — | — | 100 | Unlimited |
+| **Hosted Probe Regions** | — | 2 | 5 | 15 | Unlimited |
+| **Hosted Endpoints** | — | 5 | 25 | 100 | Unlimited |
 | **Data Retention** | 5 days | 30 days | 90 days | 90 days | Custom |
 | **Auto-Renewal Window** | 5 days | 30 days | 30 days | 30 days | 30 days |
 | **Organizations** | — | — | Yes | Yes | Yes |

--- a/backend/docs/BILLING.md
+++ b/backend/docs/BILLING.md
@@ -14,6 +14,7 @@ KrakenKey uses Stripe for subscription management with five plan tiers that cont
 | **Scan Interval** | 60 min | 30 min | 5 min | 1 min | Custom |
 | **Hosted Probe Regions** | — | 2 | 5 | 15 | Unlimited |
 | **Hosted Endpoints** | — | 5 | 25 | 100 | Unlimited |
+| **Hosted Scan Interval** | — | 30 min | 15 min | 5 min | 1 min |
 | **Data Retention** | 5 days | 30 days | 90 days | 90 days | Custom |
 | **Auto-Renewal Window** | 5 days | 30 days | 30 days | 30 days | 30 days |
 | **Organizations** | — | — | Yes | Yes | Yes |

--- a/backend/docs/ENDPOINTS.md
+++ b/backend/docs/ENDPOINTS.md
@@ -18,8 +18,8 @@ KrakenKey can monitor TLS endpoints (servers) to track certificate expiry, trust
 | Feature | Free | Starter | Team | Business | Enterprise |
 |---------|------|---------|------|----------|------------|
 | Endpoints | 3 | 10 | 25 | 75 | Unlimited |
-| Hosted Probe Regions | — | — | 5 | 15 | Unlimited |
-| Hosted Endpoints | — | — | — | 100 | Unlimited |
+| Hosted Probe Regions | — | 2 | 5 | 15 | Unlimited |
+| Hosted Endpoints | — | 5 | 25 | 100 | Unlimited |
 | Scan Interval | 60 min | 30 min | 5 min | 1 min | Custom |
 
 ## API Endpoints

--- a/backend/docs/ENDPOINTS.md
+++ b/backend/docs/ENDPOINTS.md
@@ -20,6 +20,7 @@ KrakenKey can monitor TLS endpoints (servers) to track certificate expiry, trust
 | Endpoints | 3 | 10 | 25 | 75 | Unlimited |
 | Hosted Probe Regions | — | 2 | 5 | 15 | Unlimited |
 | Hosted Endpoints | — | 5 | 25 | 100 | Unlimited |
+| Hosted Scan Interval | — | 30 min | 15 min | 5 min | 1 min |
 | Scan Interval | 60 min | 30 min | 5 min | 1 min | Custom |
 
 ## API Endpoints

--- a/backend/src/billing/constants/plan-limits.ts
+++ b/backend/src/billing/constants/plan-limits.ts
@@ -39,9 +39,9 @@ export const PLAN_LIMITS: Record<SubscriptionPlan, PlanLimits> = {
     renewalWindowDays: 30,
     monitoredEndpoints: 10,
     minScanInterval: 30,
-    hostedProbeRegions: 0,
-    hostedMonitoredEndpoints: 0,
-    hostedScanInterval: 0,
+    hostedProbeRegions: 2,
+    hostedMonitoredEndpoints: 5,
+    hostedScanInterval: 30,
     scanResultRetentionDays: 30,
   },
   team: {


### PR DESCRIPTION
This pull request updates the documentation and configuration for subscription plan limits, specifically adjusting the hosted monitoring features across different tiers. The main focus is to align the documented and coded limits for hosted probe regions, hosted endpoints, and hosted scan intervals, ensuring consistency between the product documentation and backend configuration.

**Subscription plan limit updates:**

* Updated the `PLAN_LIMITS` in `plan-limits.ts` to set `hostedProbeRegions` to 2, `hostedMonitoredEndpoints` to 5, and `hostedScanInterval` to 30 (minutes) for the Starter plan, reflecting new plan entitlements.

**Documentation consistency:**

* Updated `BILLING.md` to reflect the new limits for "Hosted Probe Regions" (2 for Starter), "Hosted Endpoints" (5 for Starter, 25 for Team), and added "Hosted Scan Interval" for each plan.
* Updated `ENDPOINTS.md` to match the new hosted monitoring limits, ensuring the documentation aligns with the backend configuration and product offering.