### PR TITLE
feat: add full certificate chain support

### DIFF
--- a/.github/workflows/backend-docker-publish.yml
+++ b/.github/workflows/backend-docker-publish.yml
@@ -91,7 +91,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
-            type=raw,value=dev
+            type=raw,value=dev,enable=${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
@@ -99,7 +99,7 @@ jobs:
         with:
           context: .
           file: ./backend/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/frontend-docker-publish.yml
+++ b/.github/workflows/frontend-docker-publish.yml
@@ -90,7 +90,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
-            type=raw,value=dev
+            type=raw,value=dev,enable=${{ github.event_name == 'pull_request' || github.ref != 'refs/heads/main' }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
@@ -98,7 +98,7 @@ jobs:
         with:
           context: .
           file: ./frontend/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/backend/src/certs/tls/dto/update-tls-crt.dto.ts
+++ b/backend/src/certs/tls/dto/update-tls-crt.dto.ts
@@ -22,4 +22,5 @@ export class UpdateTlsCrtDto extends PartialType(CreateTlsCrtDto) {
  */
 export class InternalUpdateTlsCrtDto extends UpdateTlsCrtDto {
   crtPem?: string | null;
+  chainPem?: string | null;
 }

--- a/backend/src/certs/tls/entities/tls-crt.entity.ts
+++ b/backend/src/certs/tls/entities/tls-crt.entity.ts
@@ -32,6 +32,9 @@ export class TlsCrt {
   @Column({ type: 'text', nullable: true })
   crtPem: string | null;
 
+  @Column({ type: 'text', nullable: true })
+  chainPem: string | null;
+
   @Column({ type: 'text', default: 'pending', nullable: true })
   status: CertStatus;
 

--- a/backend/src/certs/tls/processors/tls-crt-issuer.processor.spec.ts
+++ b/backend/src/certs/tls/processors/tls-crt-issuer.processor.spec.ts
@@ -43,6 +43,10 @@ describe('CertIssuerConsumer', () => {
     };
     mockCertUtil = {
       getExpirationDate: jest.fn().mockReturnValue(new Date('2027-01-01')),
+      splitChain: jest.fn().mockReturnValue({
+        leaf: '-----BEGIN CERTIFICATE-----\ncert\n-----END CERTIFICATE-----',
+        intermediates: null,
+      }),
     };
 
     const mockUserRepo = {
@@ -77,7 +81,7 @@ describe('CertIssuerConsumer', () => {
       });
       expect(mockTlsService.updateInternal).toHaveBeenCalledWith(
         1,
-        { crtPem: null },
+        { crtPem: null, chainPem: null },
         'issuing',
       );
       expect(mockAcme.issue).toHaveBeenCalled();
@@ -103,6 +107,39 @@ describe('CertIssuerConsumer', () => {
         1,
         expect.objectContaining({
           lastRenewedAt: expect.any(Date),
+        }),
+        'issued',
+      );
+    });
+
+    it('stores leaf and chain separately when ACME returns full chain', async () => {
+      mockAcme.issue.mockResolvedValue(
+        '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nintermediate\n-----END CERTIFICATE-----',
+      );
+      mockCertUtil.splitChain.mockReturnValue({
+        leaf: '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----',
+        intermediates:
+          '-----BEGIN CERTIFICATE-----\nintermediate\n-----END CERTIFICATE-----',
+      });
+
+      const job = {
+        name: 'tlsCertIssuance',
+        data: { certId: 1 },
+      } as any;
+
+      await processor.process(job);
+
+      expect(mockCertUtil.splitChain).toHaveBeenCalledWith(
+        '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nintermediate\n-----END CERTIFICATE-----',
+      );
+      expect(mockTlsService.updateInternal).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          crtPem:
+            '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----',
+          chainPem:
+            '-----BEGIN CERTIFICATE-----\nintermediate\n-----END CERTIFICATE-----',
+          expiresAt: expect.any(Date),
         }),
         'issued',
       );
@@ -137,7 +174,7 @@ describe('CertIssuerConsumer', () => {
       );
       expect(mockTlsService.updateInternal).toHaveBeenCalledWith(
         1,
-        { crtPem: null },
+        { crtPem: null, chainPem: null },
         'failed',
       );
     });
@@ -153,7 +190,7 @@ describe('CertIssuerConsumer', () => {
       await expect(processor.process(job)).rejects.toThrow('ACME timeout');
       expect(mockTlsService.updateInternal).toHaveBeenCalledWith(
         1,
-        { crtPem: null },
+        { crtPem: null, chainPem: null },
         'failed',
       );
     });

--- a/backend/src/certs/tls/processors/tls-crt-issuer.processor.ts
+++ b/backend/src/certs/tls/processors/tls-crt-issuer.processor.ts
@@ -78,7 +78,7 @@ export class CertIssuerConsumer extends WorkerHost {
     if (!raw.includes('-----BEGIN') || !raw.includes('-----END')) {
       await this.tlsService.updateInternal(
         csrRecord.id,
-        { crtPem: null },
+        { crtPem: null, chainPem: null },
         CertStatus.FAILED,
       );
       throw new Error(
@@ -96,22 +96,25 @@ export class CertIssuerConsumer extends WorkerHost {
 
       await this.tlsService.updateInternal(
         csrRecord.id,
-        { crtPem: null },
+        { crtPem: null, chainPem: null },
         statusDuringProcess,
       );
 
       // ACME issuance handles DNS-01 challenge creation, validation, and cert retrieval
-      const crtPem = await this.acmeStrategy.issue(
+      const fullChainPem = await this.acmeStrategy.issue(
         this.csrUtilService.formatPem(csrRecord.rawCsr),
         this.dnsStrategy,
       );
+
+      const { leaf: crtPem, intermediates: chainPem } =
+        this.certUtilService.splitChain(fullChainPem);
 
       const expiresAt = this.certUtilService.getExpirationDate(crtPem);
 
       const updateData: InternalUpdateTlsCrtDto & {
         expiresAt: Date;
         lastRenewedAt?: Date;
-      } = { crtPem, expiresAt };
+      } = { crtPem, chainPem, expiresAt };
       if (isRenewal) {
         updateData.lastRenewedAt = new Date();
       }
@@ -158,7 +161,7 @@ export class CertIssuerConsumer extends WorkerHost {
       // Mark as failed and let BullMQ retry the job
       await this.tlsService.updateInternal(
         csrRecord.id,
-        { crtPem: null },
+        { crtPem: null, chainPem: null },
         CertStatus.FAILED,
       );
       if (csrRecord.user) {

--- a/backend/src/certs/tls/tls.controller.spec.ts
+++ b/backend/src/certs/tls/tls.controller.spec.ts
@@ -14,6 +14,7 @@ describe('TlsController', () => {
       findAll: jest.fn(),
       findOne: jest.fn(),
       getDetails: jest.fn(),
+      getChain: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
       renew: jest.fn(),
@@ -81,6 +82,29 @@ describe('TlsController', () => {
 
       expect(controller.getDetails(mockReq, '42')).toEqual(details);
       expect(mockService.getDetails).toHaveBeenCalledWith(42, userId);
+    });
+  });
+
+  describe('getChain', () => {
+    it('passes numeric id and userId to service.getChain()', () => {
+      const chainInfo = {
+        leafCert: {
+          serialNumber: '03A1',
+          issuer: 'CN=R3',
+          subject: 'CN=example.com',
+          validFrom: '2025-06-15T00:00:00.000Z',
+          validTo: '2026-06-15T00:00:00.000Z',
+          keyType: 'RSA',
+          keySize: 2048,
+          fingerprint: 'AB:CD',
+        },
+        intermediates: [],
+        fullChainPem: 'full-chain-pem',
+      };
+      mockService.getChain.mockReturnValue(chainInfo);
+
+      expect(controller.getChain(mockReq, '42')).toEqual(chainInfo);
+      expect(mockService.getChain).toHaveBeenCalledWith(42, userId);
     });
   });
 

--- a/backend/src/certs/tls/tls.controller.ts
+++ b/backend/src/certs/tls/tls.controller.ts
@@ -73,6 +73,23 @@ export class TlsController {
     return this.tlsService.getDetails(+id, req.user.userId);
   }
 
+  @Get(':id/chain')
+  @ApiOperation({
+    summary: 'Get full certificate chain with parsed details',
+  })
+  @ApiParam({ name: 'id', description: 'Certificate ID' })
+  @ApiResponse({
+    status: 200,
+    description:
+      'Full chain info: leaf cert details, intermediate details, and full chain PEM',
+  })
+  @ApiResponse({ status: 400, description: 'Certificate not yet issued' })
+  @ApiResponse({ status: 404, description: 'Certificate not found' })
+  @RateLimitCategoryDecorator(RateLimitCategory.AUTHENTICATED_READ)
+  getChain(@Request() req: RequestWithUser, @Param('id') id: string) {
+    return this.tlsService.getChain(+id, req.user.userId);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get certificate details' })
   @ApiParam({ name: 'id', description: 'Certificate ID' })

--- a/backend/src/certs/tls/tls.service.spec.ts
+++ b/backend/src/certs/tls/tls.service.spec.ts
@@ -86,6 +86,20 @@ describe('TlsService', () => {
               keySize: 2048,
               fingerprint: 'AB:CD:EF:01:23:45:67:89',
             }),
+            getChainInfo: jest.fn().mockReturnValue({
+              leafCert: {
+                serialNumber: '03A1B2C3D4E5F6',
+                issuer: "C=US, O=Let's Encrypt, CN=R3",
+                subject: 'CN=example.com',
+                validFrom: '2025-06-15T00:00:00.000Z',
+                validTo: '2026-06-15T00:00:00.000Z',
+                keyType: 'RSA',
+                keySize: 2048,
+                fingerprint: 'AB:CD:EF:01:23:45:67:89',
+              },
+              intermediates: [],
+              fullChainPem: 'full-chain-pem',
+            }),
           },
         },
         {
@@ -344,6 +358,57 @@ describe('TlsService', () => {
       mockRepository.findOneBy.mockResolvedValue(null);
 
       await expect(service.getDetails(999, userId)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ─── getChain ──────────────────────────────────────────────────────────
+  describe('getChain', () => {
+    const issuedCert = {
+      id: 1,
+      userId,
+      status: 'issued',
+      crtPem: '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----',
+      chainPem:
+        '-----BEGIN CERTIFICATE-----\nintermediate\n-----END CERTIFICATE-----',
+    };
+
+    it('returns chain info for issued cert', async () => {
+      mockRepository.findOneBy.mockResolvedValue({ ...issuedCert });
+
+      const result = await service.getChain(1, userId);
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          leafCert: expect.objectContaining({
+            serialNumber: '03A1B2C3D4E5F6',
+          }),
+          intermediates: [],
+          fullChainPem: 'full-chain-pem',
+        }),
+      );
+      expect(certUtilService.getChainInfo).toHaveBeenCalledWith(
+        issuedCert.crtPem,
+        issuedCert.chainPem,
+      );
+    });
+
+    it('throws BadRequestException when crtPem is null', async () => {
+      mockRepository.findOneBy.mockResolvedValue({
+        ...issuedCert,
+        crtPem: null,
+      });
+
+      await expect(service.getChain(1, userId)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws NotFoundException when cert not found', async () => {
+      mockRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.getChain(999, userId)).rejects.toThrow(
         NotFoundException,
       );
     });

--- a/backend/src/certs/tls/tls.service.ts
+++ b/backend/src/certs/tls/tls.service.ts
@@ -28,6 +28,7 @@ import type {
   RevokeTlsCertResponse,
   TlsCertJobPayload,
   TlsCertDetails,
+  TlsCertChainInfo,
 } from '@krakenkey/shared';
 import { AcmeIssuerStrategy } from './strategies/acme-issuer.strategy';
 import { EmailService } from '../../notifications/email.service';
@@ -163,6 +164,18 @@ export class TlsService {
     }
 
     return this.certUtilService.getDetails(cert.crtPem);
+  }
+
+  async getChain(id: number, userId: string): Promise<TlsCertChainInfo> {
+    const cert = await this.findOne(id, userId);
+
+    if (!cert.crtPem) {
+      throw new BadRequestException(
+        'Certificate has not been issued yet. Chain is only available for issued certificates.',
+      );
+    }
+
+    return this.certUtilService.getChainInfo(cert.crtPem, cert.chainPem);
   }
 
   async update(

--- a/backend/src/certs/tls/util/cert-util.service.spec.ts
+++ b/backend/src/certs/tls/util/cert-util.service.spec.ts
@@ -97,6 +97,83 @@ describe('CertUtilService', () => {
     });
   });
 
+  // ─── splitChain ──────────────────────────────────────────────────────────
+  describe('splitChain', () => {
+    const cert1 =
+      '-----BEGIN CERTIFICATE-----\nleafdata\n-----END CERTIFICATE-----';
+    const cert2 =
+      '-----BEGIN CERTIFICATE-----\nintermediate1\n-----END CERTIFICATE-----';
+    const cert3 =
+      '-----BEGIN CERTIFICATE-----\nintermediate2\n-----END CERTIFICATE-----';
+
+    it('returns leaf only when PEM contains a single cert', () => {
+      const result = service.splitChain(cert1);
+      expect(result.leaf).toBe(cert1);
+      expect(result.intermediates).toBeNull();
+    });
+
+    it('splits two concatenated certs into leaf and intermediates', () => {
+      const result = service.splitChain(`${cert1}\n${cert2}`);
+      expect(result.leaf).toBe(cert1);
+      expect(result.intermediates).toBe(cert2);
+    });
+
+    it('splits three concatenated certs into leaf and two intermediates', () => {
+      const result = service.splitChain(`${cert1}\n${cert2}\n${cert3}`);
+      expect(result.leaf).toBe(cert1);
+      expect(result.intermediates).toBe(`${cert2}\n${cert3}`);
+    });
+
+    it('throws for empty string', () => {
+      expect(() => service.splitChain('')).toThrow(
+        'No certificates found in PEM data',
+      );
+    });
+
+    it('throws when no valid PEM blocks found', () => {
+      expect(() => service.splitChain('not a cert')).toThrow(
+        'No certificates found in PEM data',
+      );
+    });
+  });
+
+  // ─── getChainInfo ───────────────────────────────────────────────────────
+  describe('getChainInfo', () => {
+    const leafPem =
+      '-----BEGIN CERTIFICATE-----\nleaf\n-----END CERTIFICATE-----';
+    const intPem1 =
+      '-----BEGIN CERTIFICATE-----\nint1\n-----END CERTIFICATE-----';
+    const intPem2 =
+      '-----BEGIN CERTIFICATE-----\nint2\n-----END CERTIFICATE-----';
+
+    it('returns leaf details and empty intermediates when chainPem is null', () => {
+      const result = service.getChainInfo(leafPem, null);
+
+      expect(result.leafCert).toEqual(
+        expect.objectContaining({ serialNumber: '03A1B2C3D4E5F6' }),
+      );
+      expect(result.intermediates).toEqual([]);
+      expect(result.fullChainPem).toBe(leafPem);
+    });
+
+    it('parses one intermediate cert', () => {
+      const result = service.getChainInfo(leafPem, intPem1);
+
+      expect(result.intermediates).toHaveLength(1);
+      expect(result.intermediates[0]).toEqual(
+        expect.objectContaining({ serialNumber: '03A1B2C3D4E5F6' }),
+      );
+      expect(result.fullChainPem).toBe(`${leafPem}\n${intPem1}`);
+    });
+
+    it('parses two intermediate certs', () => {
+      const result = service.getChainInfo(leafPem, `${intPem1}\n${intPem2}`);
+
+      expect(result.intermediates).toHaveLength(2);
+      expect(result.fullChainPem).toBe(`${leafPem}\n${intPem1}\n${intPem2}`);
+    });
+  });
+
   // ─── isExpiringSoon ───────────────────────────────────────────────────────
   describe('isExpiringSoon', () => {
     it('returns true when cert expires within 30 days', () => {

--- a/backend/src/certs/tls/util/cert-util.service.ts
+++ b/backend/src/certs/tls/util/cert-util.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { X509Certificate } from 'crypto';
-import type { TlsCertDetails } from '@krakenkey/shared';
+import type {
+  TlsCertDetails,
+  TlsCertChainEntry,
+  TlsCertChainInfo,
+} from '@krakenkey/shared';
 
 @Injectable()
 export class CertUtilService {
@@ -81,5 +85,50 @@ export class CertUtilService {
       }
       throw new Error('Failed to parse certificate details: Unknown error');
     }
+  }
+
+  splitChain(fullPem: string): { leaf: string; intermediates: string | null } {
+    const certs = this.splitPemCerts(fullPem);
+    if (certs.length === 0) {
+      throw new Error('No certificates found in PEM data');
+    }
+    const leaf = certs[0];
+    const intermediates = certs.length > 1 ? certs.slice(1).join('\n') : null;
+    return { leaf, intermediates };
+  }
+
+  getChainInfo(leafPem: string, chainPem: string | null): TlsCertChainInfo {
+    const leafDetails = this.getDetails(leafPem);
+    const intermediates: TlsCertChainEntry[] = [];
+
+    if (chainPem) {
+      const certs = this.splitPemCerts(chainPem);
+      for (const pem of certs) {
+        intermediates.push(this.getChainEntry(pem));
+      }
+    }
+
+    const fullChainPem = chainPem ? `${leafPem}\n${chainPem}` : leafPem;
+
+    return { leafCert: leafDetails, intermediates, fullChainPem };
+  }
+
+  private getChainEntry(certPem: string): TlsCertChainEntry {
+    const cert = new X509Certificate(certPem);
+    return {
+      serialNumber: cert.serialNumber,
+      issuer: cert.issuer.replace(/\n/g, ', '),
+      subject: cert.subject.replace(/\n/g, ', '),
+      validFrom: new Date(cert.validFrom).toISOString(),
+      validTo: new Date(cert.validTo).toISOString(),
+      fingerprint: cert.fingerprint256,
+    };
+  }
+
+  private splitPemCerts(pem: string): string[] {
+    const matches = pem.match(
+      /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g,
+    );
+    return matches ?? [];
   }
 }

--- a/backend/src/migrations/1777000000000-AddCertChainPem.ts
+++ b/backend/src/migrations/1777000000000-AddCertChainPem.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCertChainPem1777000000000 implements MigrationInterface {
+  name = 'AddCertChainPem1777000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "tls_crt"
+        ADD COLUMN IF NOT EXISTS "chainPem" TEXT
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "tls_crt"
+        DROP COLUMN IF EXISTS "chainPem"
+    `);
+  }
+}

--- a/frontend/src/test/mocks/data.ts
+++ b/frontend/src/test/mocks/data.ts
@@ -53,6 +53,7 @@ export const mockCerts: TlsCert[] = [
     },
     crtPem:
       '-----BEGIN CERTIFICATE-----\nfake-cert-pem\n-----END CERTIFICATE-----',
+    chainPem: null,
     status: 'issued',
     expiresAt: '2026-01-01T00:00:00.000Z',
     lastRenewedAt: null,
@@ -75,6 +76,7 @@ export const mockCerts: TlsCert[] = [
       extensions: [],
     },
     crtPem: null,
+    chainPem: null,
     status: 'pending',
     expiresAt: null,
     lastRenewedAt: null,

--- a/shared/src/types/tls-cert.ts
+++ b/shared/src/types/tls-cert.ts
@@ -17,6 +17,7 @@ export interface TlsCert {
   rawCsr: string;
   parsedCsr: ParsedCsr;
   crtPem: string | null;
+  chainPem: string | null;
   status: CertStatus;
   expiresAt: string | null;
   lastRenewedAt: string | null;
@@ -70,6 +71,21 @@ export interface TlsCertDetails {
   keyType: string;
   keySize: number;
   fingerprint: string;
+}
+
+export interface TlsCertChainEntry {
+  serialNumber: string;
+  issuer: string;
+  subject: string;
+  validFrom: string;
+  validTo: string;
+  fingerprint: string;
+}
+
+export interface TlsCertChainInfo {
+  leafCert: TlsCertDetails;
+  intermediates: TlsCertChainEntry[];
+  fullChainPem: string;
 }
 
 export interface TlsCertJobPayload {


### PR DESCRIPTION
## Summary
- Split ACME response into leaf cert (`crtPem`) and intermediate chain (`chainPem`), stored separately in the database
- Add `GET /certs/tls/:id/chain` endpoint returning leaf details, intermediate details, and full chain PEM
- Add `chainPem` column to `TlsCrt` entity with database migration
- Add chain splitting, parsing, and assembly utilities to `CertUtilService`
- Update shared types with `TlsCertChainEntry` and `TlsCertChainInfo` interfaces

## Test plan
- [x] 13 new unit tests covering `splitChain`, `getChainInfo`, `getChain` service/controller, and processor chain splitting
- [x] All 428 backend tests pass
- [x] Verify migration runs cleanly on staging database
- [x] End-to-end: issue a cert via ACME and confirm chain endpoint returns intermediates