### PR TITLE
docs: document public scan API, activation funnel, cert chain, and probe env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Key variables:
 | `KK_REDIS_URL` | Redis connection URL |
 | `KK_JWT_SECRET` | JWT signing secret |
 | `KK_ACME_EMAIL` | Email for ACME account registration |
+| `KK_PROBE_INTERNAL_URL` | Internal URL to proxy public scan requests to the probe (e.g. `http://krakenkey-probe:8081`) |
+| `KK_PROBE_SCAN_SECRET` | Bearer secret for API → probe scan calls; must match `KK_PROBE_SCAN_API_SECRET` on the probe |
 
 See the env template for the full list.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to the KrakenKey backend application are documented here.
+
+## [Unreleased]
+
+### Added
+
+- **Certificate Chain Support** ([PR #79](https://github.com/KrakenKey/app/pull/79))
+  - New endpoint: `GET /certs/tls/:id/chain` — returns leaf cert details, per-intermediate chain entries, `chainPem` (intermediates only), and `fullChainPem` (leaf + intermediates)
+  - `chainPem` column added to `TlsCrt` entity; database migration included
+  - New shared types exported from `@krakenkey/shared`: `TlsCertChainEntry`, `TlsCertChainInfo`
+  - New `CertUtilService` utilities: `splitChain`, `getChainInfo`, `getChain`
+
+### Suggested version bump
+
+No formal version file in this repo. Recommend tagging `v0.4.0` once PR #79 merges (minor feature addition; no breaking changes).
+
+---
+
+## [2026-05-03]
+
+### Added
+
+- **Public Scan API** ([PR #77](https://github.com/KrakenKey/app/pull/77), [PR #78](https://github.com/KrakenKey/app/pull/78))
+  - New endpoint: `POST /public/scan` — unauthenticated, rate-limited, SSRF-protected
+  - Proxies scan requests to the internal probe service via `KK_PROBE_INTERNAL_URL`
+  - New `PublicScanModule` (controller, service, DTO)
+  - New shared types: `PublicScanRequest`, `PublicScanResponse` in `shared/src/types/public-scan.ts`
+  - New route constant `PUBLIC_SCAN` in `shared/src/constants/routes.ts`
+  - New dependencies: `@nestjs/axios`, `axios`
+  - See [`docs/PUBLIC_SCAN_API.md`](PUBLIC_SCAN_API.md) for endpoint details and configuration
+
+---
+
+## [2026-04-30]
+
+### Added
+
+- **Activation Funnel** ([PR #76](https://github.com/KrakenKey/app/pull/76))
+  - New `User` entity fields (with migration): `firstDomainAddedAt`, `firstCertIssuedAt`, `onboardingEmailSentAt`
+  - Welcome email sent on signup via `EmailService.sendWelcome`
+  - `ActivationReminderService`: scheduled service that sends an activation reminder 24 hours after signup if the user has not yet added a domain
+  - `DomainsService` sets `firstDomainAddedAt` when a user adds their first domain
+  - `CertIssuerConsumer` sets `firstCertIssuedAt` when a user's first certificate is issued

--- a/docs/PUBLIC_SCAN_API.md
+++ b/docs/PUBLIC_SCAN_API.md
@@ -1,0 +1,63 @@
+# Public Scan API
+
+The public scan API lets unauthenticated users scan a public TLS endpoint. KrakenKey proxies the request to the internal probe service, applying SSRF protection and rate limiting before forwarding.
+
+This endpoint backs the free TLS scanner at [krakenkey.io/scanner](https://krakenkey.io/scanner).
+
+## Endpoint
+
+```
+POST /public/scan
+```
+
+No authentication required.
+
+## Request body
+
+```json
+{
+  "hostname": "example.com",
+  "port": 443
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `hostname` | `string` | Yes | Hostname to scan. Must be a publicly routable address. |
+| `port` | `number` | No | TCP port (default `443`). |
+
+## Response
+
+Returns the probe's scan result. See `shared/src/types/public-scan.ts` for the `PublicScanResponse` type.
+
+## Errors
+
+| Status | Meaning |
+|--------|---------|
+| `400` | Invalid hostname or port |
+| `422` | Hostname resolves to a private/reserved IP (SSRF blocked) |
+| `429` | Rate limit exceeded |
+| `502` | Probe unreachable or returned an error |
+
+## Security
+
+- **SSRF protection** — Private, loopback, link-local, and reserved IP ranges are rejected before the request is proxied.
+- **Rate limiting** — Enforced per client IP via the NestJS throttler. Excessive requests return `429`.
+- **No authentication** — Intentionally unauthenticated to support the public scanner page at [krakenkey.io/scanner](https://krakenkey.io/scanner).
+
+## Configuration
+
+Set the following variables on the API service:
+
+| Variable | Description |
+|----------|-------------|
+| `KK_PROBE_INTERNAL_URL` | Internal base URL of the probe (e.g. `http://krakenkey-probe:8081`) |
+| `KK_PROBE_SCAN_SECRET` | Bearer token forwarded to `POST /scan` on the probe — must equal `KK_PROBE_SCAN_API_SECRET` on the probe side |
+
+Both variables are required when `PublicScanModule` is loaded. See [krakenkey/infra-int](https://github.com/KrakenKey/infra-int) for the Docker Compose network configuration that places the probe on an internal bridge reachable by this URL.
+
+## Related
+
+- [`docs/CHANGELOG.md`](CHANGELOG.md) — feature history
+- [krakenkey/probe — On-Demand Scan API](https://github.com/KrakenKey/probe) — probe-side endpoint documentation
+- [krakenkey/infra-int](https://github.com/KrakenKey/infra-int) — Docker Compose networking


### PR DESCRIPTION
## Documentation gaps addressed\n\nScanned PRs #76, #77/#78, and #79 (week of 2026-04-28).\n\n### Stale content fixed\n\n- **`README.md` env vars table** — Two probe integration variables (`KK_PROBE_INTERNAL_URL`, `KK_PROBE_SCAN_SECRET`) were added to `.env.template` in PR #77/#78 but were missing from the README's key variables table. Added.\n\n### New docs added\n\n**`docs/CHANGELOG.md`** (new file) — Tracks notable changes per release:\n- `[Unreleased]` — Certificate Chain Support (PR #79, pending merge): new `GET /certs/tls/:id/chain` endpoint, `chainPem` column + migration, new shared types `TlsCertChainEntry`/`TlsCertChainInfo`\n- `[2026-05-03]` — Public Scan API (PRs #77, #78): new `POST /public/scan` endpoint, `PublicScanModule`, shared types, `@nestjs/axios` dependency\n- `[2026-04-30]` — Activation Funnel (PR #76): new `User` fields with migration, welcome email on signup, `ActivationReminderService` (24-hour drip)\n\n**`docs/PUBLIC_SCAN_API.md`** (new file) — Reference for the unauthenticated `POST /public/scan` endpoint:\n- Request/response shape\n- Error codes (400 invalid input, 422 SSRF blocked, 429 rate limited, 502 probe error)\n- Security guarantees (SSRF protection, per-IP rate limiting)\n- Required env vars and cross-link to infra-int for Docker Compose network config\n\n### Documentation gaps noted (not fixed here)\n\n- The `User` auth response now includes `firstDomainAddedAt`, `firstCertIssuedAt`, and `onboardingEmailSentAt` fields (PR #76). The OpenAPI spec (auto-generated via `yarn openapi:export`) will reflect these once it is re-exported, but there is no human-readable API reference for the activation-related semantics. A future doc could describe the activation state machine.\n\n### Suggested version bump\n\nThe app does not use a semver version file, but two significant minor features have shipped (public scan + activation funnel). Recommend tagging `v0.4.0` once PR #79 (cert chain) merges, to signal the cluster of new capabilities.\n\n## Related PRs\n- KrakenKey/app#76 — Activation Funnel\n- KrakenKey/app#77, #78 — Public Scan\n- KrakenKey/app#79 — Certificate Chain (open)\n- KrakenKey/probe#12 — Probe `/scan` endpoint\n- KrakenKey/infra-int#20 — Docker Compose probe networking\n\n---\n_Generated by [Claude Code](https://claude.ai/code/session_01Pn1xPjkSKL2oCLzMYhF8Wy)_