### PR TITLE
docs: add CHANGELOG and PUBLIC_SCAN_API reference (weekly audit)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+Notable changes to the KrakenKey API, grouped by release.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Dates are merge dates.
+
+---
+
+## [Unreleased]
+
+### Added
+- `GET /certs/tls/:id/chain` — returns intermediate CA chain details: per-entry subject, issuer, fingerprint, notAfter; plus `chainPem` (intermediates only) and `fullChainPem` (leaf + intermediates) fields. New `chainPem` column added to `tls_cert` table via migration. New shared types: `TlsCertChainEntry`, `TlsCertChainInfo`. (PR #79)
+
+---
+
+## [2026-05-03] — Public Scan API
+
+### Added
+- `POST /public/scan` — unauthenticated endpoint that proxies free TLS scan requests to the hosted probe. SSRF-protected (private IP ranges blocked), per-IP rate-limited. Request: `{ host, port }`. Response: full TLS scan result. (PRs #77, #78)
+- `PublicScanModule` with `PublicScanService` and `PublicScanController`.
+- New shared types: `PublicScanRequest`, `PublicScanResponse`.
+- `@nestjs/axios` dependency for probe proxying.
+- New env vars: `KK_PROBE_INTERNAL_URL`, `KK_PROBE_SCAN_SECRET` (see [infra-int ENV_VARS.md](https://github.com/krakenkey/infra-int/blob/main/docs/ENV_VARS.md)).
+
+---
+
+## [2026-04-30] — Activation Funnel
+
+### Added
+- `User` entity fields: `firstDomainAddedAt`, `firstCertIssuedAt`, `onboardingEmailSentAt` — tracked via TypeORM migration.
+- Welcome email sent on first signup via `ActivationReminderService`.
+- 24-hour drip email if first domain is not added within 24 hours of signup.
+- `ActivationReminderService` scheduled via NestJS cron. (PR #76)
+
+---
+
+## [2026-04-08] — Plan Limits Update
+
+### Changed
+- Hosted probe limits for Starter plan updated: 2 hosted probe regions, 5 hosted monitored endpoints, 30-minute hosted scan interval. (PR #75)
+
+---
+
+## [2026-03-27] — Security Hardening + Scrypt
+
+### Added
+- API key hashing switched from bcrypt to scrypt for improved performance under load. (PR #26)
+- HMAC-SHA256 signing for service keys using `KK_HMAC_SECRET`. (PR #25)
+- CSRF protection on OAuth callback. (PR #22)
+- Log sanitization to prevent sensitive fields from appearing in application logs. (PR #21)
+
+### Changed
+- Code coverage raised above 80% across backend modules. (PR #20)
+
+---
+
+## [2026-03-27] — Hosted Probe + Billing
+
+### Added
+- Hosted probe mode: probe registers via service key (`kk_svc_`), receives endpoint config from API by region. (PR #23)
+- Prorated plan upgrades: upgrade mid-cycle charges only for remaining days. (PR #18)
+- Organization billing: org-level Stripe subscription management. (PR #19)
+
+---
+
+## [2026-03-12] — Teams + Orgs RBAC
+
+### Added
+- Organizations and RBAC: create orgs, invite members, assign roles (owner/admin/member). (PR #16)
+- Teams endpoint: `GET /organizations/:id/members`. (PR #17)

--- a/docs/PUBLIC_SCAN_API.md
+++ b/docs/PUBLIC_SCAN_API.md
@@ -1,0 +1,128 @@
+# Public Scan API
+
+The Public Scan API exposes a single unauthenticated endpoint that proxies TLS scan requests to a hosted probe. It is designed for the [/scanner](https://krakenkey.com/scanner) page and third-party integrations that need on-demand TLS inspection without a KrakenKey account.
+
+---
+
+## Endpoint
+
+```
+POST /public/scan
+```
+
+**Authentication**: None required.
+
+**Rate limiting**: Per-IP, enforced at the API gateway layer. Repeated bursts from the same IP will receive `429 Too Many Requests`.
+
+**SSRF protection**: The API validates that the target hostname resolves to a public, routable IP address before forwarding the request to the probe. Private ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `127.0.0.0/8`, link-local, loopback) are rejected with `400 Bad Request`.
+
+---
+
+## Request
+
+### Headers
+
+| Header | Value |
+|--------|-------|
+| `Content-Type` | `application/json` |
+
+### Body
+
+```json
+{
+  "host": "example.com",
+  "port": 443
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `host` | string | Yes | Hostname or IP to scan. Must resolve to a public IP. |
+| `port` | integer | No | TCP port for TLS handshake. Defaults to `443`. |
+
+---
+
+## Response
+
+### 200 OK
+
+Returns the TLS scan result from the hosted probe.
+
+```json
+{
+  "host": "example.com",
+  "port": 443,
+  "reachable": true,
+  "certValid": true,
+  "certExpiry": "2026-08-01T00:00:00Z",
+  "daysUntilExpiry": 81,
+  "issuer": "Let's Encrypt",
+  "subject": "CN=example.com",
+  "sans": ["example.com", "www.example.com"],
+  "protocol": "TLSv1.3",
+  "cipherSuite": "TLS_AES_128_GCM_SHA256",
+  "scannedAt": "2026-05-12T14:32:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `host` | string | The scanned hostname. |
+| `port` | integer | The scanned port. |
+| `reachable` | boolean | Whether the host accepted a TLS connection. |
+| `certValid` | boolean | Whether the certificate chain is valid and trusted. |
+| `certExpiry` | string (ISO 8601) | Certificate expiration time. |
+| `daysUntilExpiry` | integer | Days remaining until expiry. Negative if already expired. |
+| `issuer` | string | Common name of the issuing CA. |
+| `subject` | string | Certificate subject DN. |
+| `sans` | string[] | Subject Alternative Names on the certificate. |
+| `protocol` | string | Negotiated TLS protocol version (e.g., `TLSv1.3`). |
+| `cipherSuite` | string | Negotiated cipher suite. |
+| `scannedAt` | string (ISO 8601) | Timestamp of the scan. |
+
+### Error Responses
+
+| Status | Reason |
+|--------|--------|
+| `400 Bad Request` | Missing `host`, or `host` resolves to a private/reserved IP address (SSRF blocked). |
+| `429 Too Many Requests` | Rate limit exceeded for this IP address. |
+| `502 Bad Gateway` | Hosted probe is unreachable or returned an unexpected response. |
+| `504 Gateway Timeout` | Probe did not respond within the allowed window. |
+
+---
+
+## Implementation Notes
+
+### Module
+
+The endpoint is implemented in `PublicScanModule` (`src/public-scan/`).
+
+### Probe Forwarding
+
+After SSRF validation, the API forwards the request to the hosted probe's `POST /scan` endpoint using `@nestjs/axios`. The probe is selected from the region pool; for the public endpoint the default region is used.
+
+### Environment Variables
+
+No additional environment variables are required for the public endpoint itself. The hosted probe it forwards to must have `KK_PROBE_SCAN_API_ENABLED=true` and a valid `KK_PROBE_SCAN_API_SECRET` configured.
+
+### Rate Limiting Configuration
+
+Rate limit thresholds are configured in the API gateway / reverse proxy layer, not within the NestJS application itself. Adjust your nginx or Cloudflare rate limit rules as needed.
+
+---
+
+## Example
+
+```bash
+curl -s -X POST https://api.krakenkey.com/public/scan \
+  -H 'Content-Type: application/json' \
+  -d '{"host": "example.com", "port": 443}' | jq .
+```
+
+---
+
+## Related
+
+- [Probe On-Demand Scan API](../../probe/README.md#on-demand-scan-api) — the internal endpoint this proxies to
+- [Scanner page](https://krakenkey.com/scanner) — UI that uses this endpoint
+- [DOMAIN_VERIFICATION_GUIDE.md](./DOMAIN_VERIFICATION_GUIDE.md)


### PR DESCRIPTION
## Weekly Documentation Audit — 2026-05-12

### Documentation Gaps Addressed

The `docs/` directory only contained `DOMAIN_VERIFICATION_GUIDE.md` and `ERROR_HANDLING.md`. Several recent significant features (Public Scan API, activation funnel, cert chain) had no changelog entries, and the `POST /public/scan` endpoint had no API reference.

| Gap | Fix |
|-----|-----|
| No `CHANGELOG.md` | Created `docs/CHANGELOG.md` covering all releases back to March 2026 |
| `POST /public/scan` endpoint undocumented | Created `docs/PUBLIC_SCAN_API.md` with full request/response reference |
| Cert chain support (PR #79) not yet logged | Added `[Unreleased]` section in CHANGELOG |
| Public Scan API (PRs #77, #78) not logged | Added `2026-05-03` release section |
| Activation funnel (PR #76) not logged | Added `2026-04-30` release section |
| Plan limits update (PR #75) not logged | Added `2026-04-08` release section |
| Earlier milestones (security hardening, hosted probe, RBAC) not logged | Added `2026-03-27` and `2026-03-12` sections |

---

### Files Changed

- `docs/CHANGELOG.md` — new file; full changelog from `[Unreleased]` back to 2026-03-12
- `docs/PUBLIC_SCAN_API.md` — new file; request/response reference, SSRF protection notes, rate limiting, error codes, and implementation notes

---

### Suggested Version Bump

Once PR #79 (cert chain) merges, tag **`v0.4.0`**:
- `v0.1.0` — initial release
- `v0.2.0` — hosted probe + billing (Mar 2026)
- `v0.3.0` — public scan API + activation funnel (May 2026)
- `v0.4.0` — certificate chain support (this cycle)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECDAzURqSKxrEaYHVEAWXk)_