### PR TITLE
chore: update actions versions

### DIFF
--- a/.github/workflows/backend-docker-publish.yml
+++ b/.github/workflows/backend-docker-publish.yml
@@ -69,16 +69,16 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -95,7 +95,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./backend/Dockerfile

--- a/.github/workflows/frontend-docker-publish.yml
+++ b/.github/workflows/frontend-docker-publish.yml
@@ -68,16 +68,16 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -94,7 +94,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./frontend/Dockerfile

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: yarn

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,7 +102,7 @@ jobs:
         run: yarn test:e2e
       - name: Upload report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-report
           path: frontend/playwright-report/


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to use the latest major versions of key actions, improving security, reliability, and compatibility. The changes primarily focus on upgrading Docker-related actions and other commonly used actions in CI/CD pipelines.

**Workflow action version upgrades:**

*Docker-related actions:*
- Upgraded `docker/login-action`, `docker/setup-buildx-action`, and `docker/metadata-action` to their latest major versions (`v4` and `v6`) in both `backend-docker-publish.yml` and `frontend-docker-publish.yml` workflows. [[1]](diffhunk://#diff-22c808a5c5c6ab9eafb0e01f900ed3236b421acb2e0e91e0d23678dea7396d17L72-R89) [[2]](diffhunk://#diff-44b226db8fde19d012282f0a98900c5bd73cdb784dfe5bfd71b29a73d20bb1cbL71-R88)
- Upgraded `docker/build-push-action` from `v6` to `v7` in both backend and frontend Docker workflows. [[1]](diffhunk://#diff-22c808a5c5c6ab9eafb0e01f900ed3236b421acb2e0e91e0d23678dea7396d17L98-R98) [[2]](diffhunk://#diff-44b226db8fde19d012282f0a98900c5bd73cdb784dfe5bfd71b29a73d20bb1cbL97-R97)

*Other action upgrades:*
- Upgraded `actions/setup-node` from `v4` to `v6` in `sync-openapi-spec.yml` to ensure compatibility with the latest Node.js versions and features.
- Upgraded `actions/upload-artifact` from `v4` to `v6` in the test workflow for improved artifact handling.