### PR TITLE
docs: weekly audit — promote TLS chain endpoint to dated release in CHANGELOG

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Dates a
 
 ## [Unreleased]
 
+---
+
+## [2026-05-28] — Certificate Chain
+
 ### Added
 - `GET /certs/tls/:id/chain` — returns intermediate CA chain details: per-entry subject, issuer, fingerprint, notAfter; plus `chainPem` (intermediates only) and `fullChainPem` (leaf + intermediates) fields. New `chainPem` column added to `tls_cert` table via migration. New shared types: `TlsCertChainEntry`, `TlsCertChainInfo`. (PR #79)
 


### PR DESCRIPTION
## Documentation Audit — Week of 2026-05-26

### Gap identified

`docs/CHANGELOG.md` had `GET /certs/tls/:id/chain` (PR #79) sitting in `[Unreleased]` indefinitely. The endpoint shipped and is live; it should be captured in a dated release section.

### Changes in this PR

- **`docs/CHANGELOG.md`** — promoted `[Unreleased]` items to `[2026-05-28] — Certificate Chain`:
  - `GET /certs/tls/:id/chain` with full description (chain entries, `chainPem`, `fullChainPem`, DB migration, shared types)
  - Reset `[Unreleased]` to empty for future work

### Suggested version bump

The undocumented chain endpoint represents a new API addition. Recommended tag: **v0.4.0** (following the existing date-based naming convention for the CHANGELOG, no semver tag exists yet for this release).

### Supersedes

Open draft PR #85 (app) — this PR covers the v0.4.0 CHANGELOG gap that #85 was tracking.

---
*Weekly documentation audit — 2026-06-02*