### PR TITLE
docs: promote chain endpoint release in CHANGELOG — weekly audit 2026-06-23

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Dates a
 
 ## [Unreleased]
 
+---
+
+## [2026-05-28] — Certificate Chain
+
 ### Added
 - `GET /certs/tls/:id/chain` — returns intermediate CA chain details: per-entry subject, issuer, fingerprint, notAfter; plus `chainPem` (intermediates only) and `fullChainPem` (leaf + intermediates) fields. New `chainPem` column added to `tls_cert` table via migration. New shared types: `TlsCertChainEntry`, `TlsCertChainInfo`. (PR #79)
 


### PR DESCRIPTION
## Weekly Documentation Audit — 2026-06-23

Supersedes #88.

### Documentation gaps identified

- `docs/CHANGELOG.md` had the `GET /certs/tls/:id/chain` endpoint in `[Unreleased]` despite the feature having shipped (PR #79 merged)
- No version tag had been proposed for this release
- `[Unreleased]` section needed to be cleared and reset for future entries

### Changes made

**`docs/CHANGELOG.md`**:

- Promoted `[Unreleased]` → `[2026-05-28] — Certificate Chain` with PR #79 reference
- Added new empty `[Unreleased]` at top for future changes
- All prior releases (`[2026-04-14]` and earlier) preserved unchanged

### Status note

#88 remains open and unmerged. This edition carries forward the same gaps — the fix is on branch `claude/nifty-shannon-q4s61x`. Close #88 once this PR is reviewed.

### Suggested version bump

**v0.4.0** — the `GET /certs/tls/:id/chain` endpoint is a new user-visible API addition. Tag `v0.4.0` on the commit that merged PR #79 (or on main once confirmed clean).